### PR TITLE
iss#3 no height results in report - fix

### DIFF
--- a/Config/dp_manage_calmrs.pro
+++ b/Config/dp_manage_calmrs.pro
@@ -79,14 +79,14 @@ PRO dp_apply_calmrs, sel_exp, mrs_strct, SEL_ONLY=sel_only, PATH=path, $
 
   COMMON dp_data
 
-  IF NOT KEYWORD_SET(verbose) THEN verbose=0
+  IF NOT KEYWORD_SET(verbose) THEN verbose = 0
 
   IF KEYWORD_SET(sel_only) THEN exps = sel_exp $
     ELSE exps = LINDGEN(N_ELEMENTS(dp_chrom))
 
   id_cal = (WHERE(STRUPCASE(sid_name) EQ 'CALIBRATION'))[0] +1
 
-  cal_names=[]
+  cal_names = []
   FOR i=0, N_ELEMENTS(exps)-1 DO $
     cal_names = [cal_names, $
         ((dp_expcfg[exps[i]]).expinfo.s_name)[WHERE((dp_expcfg[exps[i]]).expinfo.s_id EQ id_cal AND $
@@ -100,8 +100,8 @@ PRO dp_apply_calmrs, sel_exp, mrs_strct, SEL_ONLY=sel_only, PATH=path, $
     RETURN
   ENDIF
 
-  canister=(mrs_strct.canister)[0]
-  quest='Yes'
+  canister = (mrs_strct.canister)[0]
+  quest = 'Yes'
   IF cal_names[0] NE canister THEN $
     quest=DIALOG_MESSAGE('Calibration gas specification found in experiment-info file (' + cal_names[0] + ') ' + $
                          'and specification in MR Table (' + canister + ') do not match. Continue?', /QUESTION, /DEFAULT_NO)
@@ -110,7 +110,7 @@ PRO dp_apply_calmrs, sel_exp, mrs_strct, SEL_ONLY=sel_only, PATH=path, $
 
   IF quest EQ 'Yes' THEN BEGIN
     FOR i=0, N_ELEMENTS(exps)-1 DO BEGIN
-      tmp_expcfg=(dp_expcfg[exps[i]])
+      tmp_expcfg = (dp_expcfg[exps[i]])
       tmp_expcfg.cal_mrs.canister = canister
       *tmp_expcfg.cal_mrs.substance = mrs_strct.substance
       *tmp_expcfg.cal_mrs.mr_ppt = mrs_strct.mr_ppt
@@ -119,21 +119,21 @@ PRO dp_apply_calmrs, sel_exp, mrs_strct, SEL_ONLY=sel_only, PATH=path, $
       *tmp_expcfg.cal_mrs.scale = mrs_strct.scale
       *tmp_expcfg.cal_mrs.comment = mrs_strct.comment
       *tmp_expcfg.cal_mrs.unit = mrs_strct.unit
-      (dp_expcfg[exps[i]])=TEMPORARY(tmp_expcfg)
+      (dp_expcfg[exps[i]]) = TEMPORARY(tmp_expcfg)
     ENDFOR
 
     IF verbose THEN BEGIN
       print, '+++'
       print, 'imported cal mixing ratios.'
-      def_subst=substlist[sel_exp]
+      def_subst = substlist[sel_exp]
       w=REPLICATE(-1L, N_ELEMENTS(def_subst))
       FOR i=0L, N_ELEMENTS(def_subst)-1 DO $
         IF (WHERE(substance EQ def_subst[i]))[0] NE -1 $
           THEN w[i]=(WHERE(substance EQ def_subst[i]))[0]
       w1=WHERE(w EQ -1, nvd, NCOMPLEMENT=ncomplement)
       print, 'found n matches: ', ncomplement
-      missing=STRARR(N_ELEMENTS(w1))
-      missing=def_subst[w1]
+      missing = STRARR(N_ELEMENTS(w1))
+      missing = def_subst[w1]
       print, 'missing: '
       print, missing
       print, '+++'
@@ -164,12 +164,12 @@ PRO dp_remv_calmrs, sel_exp, SEL_ONLY=sel_only, LOUD=loud
   FOR i=0, N_ELEMENTS(exps)-1 DO BEGIN
     IF *(dp_expcfg[sel_exp]).cal_mrs.mr_ppt NE !NULL $
       THEN BEGIN
-        quest='Yes'
+        quest = 'Yes'
         IF loud THEN quest=DIALOG_MESSAGE('Remove Cal MR values: are you sure?', /QUESTION)
         CASE quest OF
           'Yes': $
             BEGIN
-              tmp_expcfg=(dp_expcfg[sel_exp])
+              tmp_expcfg = (dp_expcfg[sel_exp])
               tmp_expcfg.cal_mrs.canister = ''
               *tmp_expcfg.cal_mrs.substance = !NULL
               *tmp_expcfg.cal_mrs.mr_ppt = !NULL
@@ -178,7 +178,7 @@ PRO dp_remv_calmrs, sel_exp, SEL_ONLY=sel_only, LOUD=loud
               *tmp_expcfg.cal_mrs.scale = !NULL
               *tmp_expcfg.cal_mrs.comment = !NULL
               *tmp_expcfg.cal_mrs.unit = !NULL
-              (dp_expcfg[sel_exp])=TEMPORARY(tmp_expcfg)
+              (dp_expcfg[sel_exp]) = TEMPORARY(tmp_expcfg)
             END
           'No':
           ELSE:

--- a/Config/dp_manage_carryover.pro
+++ b/Config/dp_manage_carryover.pro
@@ -8,7 +8,7 @@
 ;------------------------------------------------------------------------------------------------------------------------
 PRO dp_read_cocorrparms, sel_exp, SEL_ONLY=sel_only, PATH=path, DEF_FILE=def_file, VERBOSE=verbose
 
-  IF NOT KEYWORD_SET(verbose) THEN verbose=0
+  IF NOT KEYWORD_SET(verbose) THEN verbose = 0
 
   COMMON dp_data
 
@@ -54,22 +54,22 @@ PRO dp_read_cocorrparms, sel_exp, SEL_ONLY=sel_only, PATH=path, DEF_FILE=def_fil
   IF KEYWORD_SET(sel_only) THEN exps = sel_exp ELSE exps = LINDGEN(N_ELEMENTS(dp_chrom))
 
   FOR i=0, N_ELEMENTS(exps)-1 DO BEGIN
-    tmp_expcfg=(dp_expcfg[exps[i]])
+    tmp_expcfg = (dp_expcfg[exps[i]])
     *tmp_expcfg.carryover.substance = substance
     tmp_expcfg.carryover.comment = header[0:-2]
     *tmp_expcfg.carryover.cal_to_sam = cal_to_sam
     *tmp_expcfg.carryover.sam_to_sam = sam_to_sam
     *tmp_expcfg.carryover.sam_to_cal = sam_to_cal
-    (dp_expcfg[exps[i]])=TEMPORARY(tmp_expcfg)
+    (dp_expcfg[exps[i]]) = TEMPORARY(tmp_expcfg)
 
-    tmp_chrom=(dp_chrom[exps[i]])
+    tmp_chrom = (dp_chrom[exps[i]])
     ; check for which species carry over correction is defined
       exp_subst = tmp_chrom[0].subst.name[0]
       def_subst = substance
       match_ix = arr1D_get_matchIX(exp_subst, def_subst)
       IF match_ix[0] NE -1 THEN $
         tmp_chrom.subst[match_ix].rres.active_corr[0] = !TRUE
-    (dp_chrom[exps[i]])=TEMPORARY(tmp_chrom)
+    (dp_chrom[exps[i]]) = TEMPORARY(tmp_chrom)
   ENDFOR
 
 END

--- a/Config/dp_manage_instrprc.pro
+++ b/Config/dp_manage_instrprc.pro
@@ -9,7 +9,7 @@
 ;------------------------------------------------------------------------------------------------------------------------
 FUNCTION dp_read_instrprc, sel_exp, exp_name, substlist, PATH=path, DEF_FILE=def_file, VERBOSE=verbose
 
-  IF NOT KEYWORD_SET(verbose) THEN verbose=0
+  IF NOT KEYWORD_SET(verbose) THEN verbose = 0
 
   IF NOT KEYWORD_SET(def_file) THEN $
     file=DIALOG_PICKFILE(TITLE='Please select a Precision Table.', PATH=path, FILTER='*.csv', /READ) $
@@ -19,7 +19,7 @@ FUNCTION dp_read_instrprc, sel_exp, exp_name, substlist, PATH=path, DEF_FILE=def
   IF FILE_TEST(file) EQ 0 THEN RETURN, !NULL
 
   sep = ';'
-  n_table_header=7
+  n_table_header = 7
   nl = FILE_LINES(file)
   count = nl-n_table_header
   data = STRARR(nl)
@@ -59,15 +59,15 @@ FUNCTION dp_read_instrprc, sel_exp, exp_name, substlist, PATH=path, DEF_FILE=def
   IF verbose THEN BEGIN
     print, '+++'
     print, 'imported instrument precision values for: '+exp_name
-    def_subst=substlist[sel_exp]
+    def_subst = substlist[sel_exp]
     w=REPLICATE(-1L, N_ELEMENTS(def_subst))
     FOR i=0L, N_ELEMENTS(def_subst)-1 DO $
       IF (WHERE(substance EQ def_subst[i]))[0] NE -1 THEN w[i]=(WHERE(substance EQ def_subst[i]))[0]
 
     w1=WHERE(w EQ -1, nvd, NCOMPLEMENT=ncomplement)
     print, 'found n matches: ', ncomplement
-    missing=STRARR(N_ELEMENTS(w1))
-    missing=def_subst[w1]
+    missing = STRARR(N_ELEMENTS(w1))
+    missing = def_subst[w1]
     print, 'missing: '
     print, missing
     print, '+++'
@@ -96,17 +96,17 @@ PRO dp_apply_instrprc, PRC_STRCT=prc_strct, sel_exp, SEL_ONLY=sel_only, QUIET=qu
   ok = prc_limits[0]; range definition
   bad = prc_limits[1]
 
-  IF NOT KEYWORD_SET(verbose) THEN verbose=0
+  IF NOT KEYWORD_SET(verbose) THEN verbose = 0
 
   IF KEYWORD_SET(sel_only) THEN exps = sel_exp ELSE exps = LINDGEN(N_ELEMENTS(dp_chrom))
 
   FOR n=0, N_ELEMENTS(exps)-1 DO BEGIN
-    tmp_chrom=(dp_chrom[exps[n]]) ; move data out of list...
-    tmp_expcfg=(dp_expcfg[exps[n]])
+    tmp_chrom = (dp_chrom[exps[n]]) ; move data out of list...
+    tmp_expcfg = (dp_expcfg[exps[n]])
 
     IF KEYWORD_SET(prc_strct) THEN BEGIN ; if variable supplied, update values in expcfg struct
 
-      quest='Yes'
+      quest = 'Yes'
 
       IF NOT KEYWORD_SET(quiet) THEN BEGIN
         IF STRUPCASE(instr) NE STRUPCASE(prc_strct.instrument) THEN $
@@ -128,14 +128,14 @@ PRO dp_apply_instrprc, PRC_STRCT=prc_strct, sel_exp, SEL_ONLY=sel_only, QUIET=qu
 
     ENDIF
 
-    def_subst=tmp_chrom[0].subst.name ; begin to apply...
-    n_subst=N_ELEMENTS(def_subst)
-    n_chrom=N_ELEMENTS(tmp_chrom.subst[0].rres.rsp_area.block_rsd)
-    tmp_prc_flag=LONARR(n_chrom)
+    def_subst = tmp_chrom[0].subst.name ; begin to apply...
+    n_subst = N_ELEMENTS(def_subst)
+    n_chrom = N_ELEMENTS(tmp_chrom.subst[0].rres.rsp_area.block_rsd)
+    tmp_prc_flag = LONARR(n_chrom)
 
     FOR i=0, n_subst-1 DO BEGIN ; check values for each substance
       eval_mode = (tmp_chrom.subst[i].rres.rsp_select)[0]
-      w=(WHERE(*tmp_expcfg.instr_prc.substance EQ def_subst[i]))[0]
+      w = (WHERE(*tmp_expcfg.instr_prc.substance EQ def_subst[i]))[0]
       IF w NE -1 THEN BEGIN
         CASE eval_mode OF
           0:  BEGIN
@@ -169,8 +169,8 @@ PRO dp_apply_instrprc, PRC_STRCT=prc_strct, sel_exp, SEL_ONLY=sel_only, QUIET=qu
       ENDIF
     ENDFOR
 
-    (dp_expcfg[exps[n]])=TEMPORARY(tmp_expcfg)
-    (dp_chrom[exps[n]])=TEMPORARY(tmp_chrom) ; ...move data back into list.
+    (dp_expcfg[exps[n]]) = TEMPORARY(tmp_expcfg)
+    (dp_chrom[exps[n]]) = TEMPORARY(tmp_chrom) ; ...move data back into list.
   ENDFOR
 
   IF verbose THEN print, 'Instrument precision values: applied.'
@@ -195,17 +195,17 @@ PRO dp_remv_instrprc, sel_exp, SEL_ONLY=sel_only, LOUD=loud
   FOR i=0, N_ELEMENTS(exps)-1 DO BEGIN
     IF *(dp_expcfg[sel_exp]).instr_prc.mp_ppt NE !NULL $
       THEN BEGIN
-      quest='Yes'
+      quest = 'Yes'
       IF loud THEN quest=DIALOG_MESSAGE('Remove instrument prc values: are you sure?', /QUESTION)
       CASE quest OF
         'Yes': $
           BEGIN
-          n_subst=N_ELEMENTS((dp_chrom[sel_exp])[0].subst.name)
+          n_subst = N_ELEMENTS((dp_chrom[sel_exp])[0].subst.name)
 
-          tmp_chrom=(dp_chrom[sel_exp])
-          n_chrom=N_ELEMENTS(tmp_chrom.subst[0].rres.rsp_area.block_rsd)
+          tmp_chrom = (dp_chrom[sel_exp])
+          n_chrom = N_ELEMENTS(tmp_chrom.subst[0].rres.rsp_area.block_rsd)
 
-          tmp_expcfg=(dp_expcfg[sel_exp])
+          tmp_expcfg = (dp_expcfg[sel_exp])
           tmp_expcfg.instr_prc.instrument = ''
           *tmp_expcfg.instr_prc.substance = !NULL
           *tmp_expcfg.instr_prc.mp_ppt = !NULL
@@ -221,8 +221,8 @@ PRO dp_remv_instrprc, sel_exp, SEL_ONLY=sel_only, LOUD=loud
             tmp_chrom.subst[n].rres.rsp_height.prc_flag = INTARR(n_chrom)
           ENDFOR
 
-          (dp_expcfg[sel_exp])=TEMPORARY(tmp_expcfg)
-          (dp_chrom[sel_exp])=TEMPORARY(tmp_chrom) ; ...move data back into list.
+          (dp_expcfg[sel_exp]) = TEMPORARY(tmp_expcfg)
+          (dp_chrom[sel_exp]) = TEMPORARY(tmp_chrom) ; ...move data back into list.
         END
         'No':
         ELSE:

--- a/Config/dp_manage_tgtmrs.pro
+++ b/Config/dp_manage_tgtmrs.pro
@@ -9,7 +9,7 @@
 ;------------------------------------------------------------------------------------------------------------------------
 FUNCTION dp_read_tgtmrs, PATH=path, DEF_FILE=def_file, VERBOSE=verbose
 
-  IF NOT KEYWORD_SET(verbose) THEN verbose=0
+  IF NOT KEYWORD_SET(verbose) THEN verbose = 0
 
   IF NOT KEYWORD_SET(def_file) THEN $
     file=DIALOG_PICKFILE(TITLE='Please select a Mixing Ratio Table.', PATH=path, FILTER='*.csv', /READ) $
@@ -75,13 +75,13 @@ PRO dp_apply_tgtmrs, sel_exp, tgt_strct, SEL_ONLY=sel_only, PATH=path, VERBOSE=v
 
   COMMON dp_data
 
-  IF NOT KEYWORD_SET(verbose) THEN verbose=0
+  IF NOT KEYWORD_SET(verbose) THEN verbose = 0
 
   IF KEYWORD_SET(sel_only) THEN exps = sel_exp $
     ELSE exps = LINDGEN(N_ELEMENTS(dp_chrom))
 
   FOR i=0, N_ELEMENTS(exps)-1 DO BEGIN
-    tmp_expcfg=(dp_expcfg[exps[i]])
+    tmp_expcfg = (dp_expcfg[exps[i]])
 
     *tmp_expcfg.tgt_mrs.tgt_name = tgt_strct.tgt_name
     *tmp_expcfg.tgt_mrs.substance = tgt_strct.substance
@@ -92,20 +92,20 @@ PRO dp_apply_tgtmrs, sel_exp, tgt_strct, SEL_ONLY=sel_only, PATH=path, VERBOSE=v
     *tmp_expcfg.tgt_mrs.comment = tgt_strct.comment
     *tmp_expcfg.tgt_mrs.unit = tgt_strct.unit
 
-    (dp_expcfg[exps[i]])=TEMPORARY(tmp_expcfg)
+    (dp_expcfg[exps[i]]) = TEMPORARY(tmp_expcfg)
   ENDFOR
 
   IF verbose THEN BEGIN
     print, '+++'
     print, 'imported tgt mixing ratios.'
-    def_subst=substlist[sel_exp]
+    def_subst = substlist[sel_exp]
     w=REPLICATE(-1L, N_ELEMENTS(def_subst))
     FOR i=0L, N_ELEMENTS(def_subst)-1 DO $
       IF (WHERE(substance EQ def_subst[i]))[0] NE -1 THEN w[i]=(WHERE(substance EQ def_subst[i]))[0]
     w1=WHERE(w EQ -1, nvd, NCOMPLEMENT=ncomplement)
     print, 'found n matches: ', ncomplement
-    missing=STRARR(N_ELEMENTS(w1))
-    missing=def_subst[w1]
+    missing = STRARR(N_ELEMENTS(w1))
+    missing = def_subst[w1]
     print, 'missing: '
     print, missing
     print, '+++'
@@ -133,12 +133,12 @@ PRO dp_remv_tgtmrs, sel_exp, SEL_ONLY=sel_only, LOUD=loud
   FOR i=0, N_ELEMENTS(exps)-1 DO BEGIN
     IF *(dp_expcfg[sel_exp]).tgt_mrs.mr_ppt NE !NULL $
       THEN BEGIN
-      quest='Yes'
+      quest = 'Yes'
       IF loud THEN quest=DIALOG_MESSAGE('Remove tgt MR values: are you sure?', /QUESTION)
       CASE quest OF
         'Yes': $
           BEGIN
-          tmp_expcfg=(dp_expcfg[sel_exp])
+          tmp_expcfg = (dp_expcfg[sel_exp])
           *tmp_expcfg.tgt_mrs.tgt_name = !NULL
           *tmp_expcfg.tgt_mrs.substance = !NULL
           *tmp_expcfg.tgt_mrs.mr_ppt = !NULL
@@ -147,7 +147,7 @@ PRO dp_remv_tgtmrs, sel_exp, SEL_ONLY=sel_only, LOUD=loud
           *tmp_expcfg.tgt_mrs.scale = !NULL
           *tmp_expcfg.tgt_mrs.comment = !NULL
           *tmp_expcfg.tgt_mrs.unit = !NULL
-          (dp_expcfg[sel_exp])=TEMPORARY(tmp_expcfg)
+          (dp_expcfg[sel_exp]) = TEMPORARY(tmp_expcfg)
         END
         'No':
         ELSE:

--- a/Config/dp_manage_treatcfg.pro
+++ b/Config/dp_manage_treatcfg.pro
@@ -10,14 +10,14 @@ PRO dp_read_treatcfg, sel_exp, SEL_ONLY=sel_only, FILE=file, VERBOSE=verbose
 
   COMMON DP_DATA
 
-  IF NOT KEYWORD_SET(verbose) THEN verbose=0
+  IF NOT KEYWORD_SET(verbose) THEN verbose = 0
 
   IF KEYWORD_SET(sel_only) THEN exps = sel_exp ELSE exps = LINDGEN(N_ELEMENTS(dp_chrom))
 
   FOR i=0, N_ELEMENTS(exps)-1 DO BEGIN
-    finvals=FINITE((dp_chrom[exps[i]]).subst[*].rres.rsp_area.normalised)
+    finvals = FINITE((dp_chrom[exps[i]]).subst[*].rres.rsp_area.normalised)
     finvals=REFORM(finvals, N_ELEMENTS(finvals))
-    w=WHERE(finvals NE 0)
+    w = WHERE(finvals NE 0)
     IF w[0] NE -1 THEN BEGIN
       quest=DIALOG_MESSAGE('Results found. These will be overwritten. Continue?', /QUESTION)
       IF quest EQ 'No' THEN RETURN
@@ -30,11 +30,11 @@ PRO dp_read_treatcfg, sel_exp, SEL_ONLY=sel_only, FILE=file, VERBOSE=verbose
   IF file EQ '' THEN RETURN
   IF FILE_TEST(file) EQ 0 THEN RETURN
 
-  sep=STRING(9B)
-  nl=FILE_LINES(file)
-  data=STRARR(nl)
-  nl_hdr=5
-  n_subst=nl-nl_hdr
+  sep = STRING(9B)
+  nl = FILE_LINES(file)
+  data = STRARR(nl)
+  nl_hdr = 5
+  n_subst = nl-nl_hdr
 
   OPENR, LUN, file, /GET_LUN
   READF, LUN, data
@@ -63,13 +63,13 @@ PRO dp_read_treatcfg, sel_exp, SEL_ONLY=sel_only, FILE=file, VERBOSE=verbose
   ENDFOR
 
   FOR i=0, N_ELEMENTS(exps)-1 DO BEGIN
-    tmp_expcfg=(dp_expcfg[exps[i]])
+    tmp_expcfg = (dp_expcfg[exps[i]])
     *tmp_expcfg.treatcfg.substance = substance
     *tmp_expcfg.treatcfg.cal_treat = treat_cal
     *tmp_expcfg.treatcfg.sam_treat = treat_sam
     *tmp_expcfg.treatcfg.cal_ip = ip_cal
     *tmp_expcfg.treatcfg.eval_mode = eval_mode
-    (dp_expcfg[exps[i]])=TEMPORARY(tmp_expcfg)
+    (dp_expcfg[exps[i]]) = TEMPORARY(tmp_expcfg)
   ENDFOR
 
   dp_refr_status, MESSAGE='Imported treatment config.'
@@ -89,13 +89,13 @@ PRO dp_remv_treatcfg, sel_exp, SEL_ONLY=sel_only, LOUD=loud
   COMMON DP_DATA
 
   IF KEYWORD_SET(sel_only) THEN exps = sel_exp ELSE exps = LINDGEN(N_ELEMENTS(dp_chrom))
-  IF NOT KEYWORD_SET(loud) THEN loud=0
+  IF NOT KEYWORD_SET(loud) THEN loud = 0
 
   IF loud THEN BEGIN
     FOR i=0, N_ELEMENTS(exps)-1 DO BEGIN
-      finvals=FINITE((dp_chrom[exps[i]]).subst[*].rres.rsp_area.normalised)
+      finvals = FINITE((dp_chrom[exps[i]]).subst[*].rres.rsp_area.normalised)
       finvals=REFORM(finvals, N_ELEMENTS(finvals))
-      w=WHERE(finvals NE 0)
+      w = WHERE(finvals NE 0)
       IF w[0] NE -1 THEN BEGIN
         quest=DIALOG_MESSAGE('Results found. These will be overwritten. Continue?', /QUESTION)
         IF quest EQ 'No' THEN RETURN
@@ -104,13 +104,13 @@ PRO dp_remv_treatcfg, sel_exp, SEL_ONLY=sel_only, LOUD=loud
   ENDIF
 
   FOR i=0, N_ELEMENTS(exps)-1 DO BEGIN
-    tmp_expcfg=(dp_expcfg[exps[i]])
+    tmp_expcfg = (dp_expcfg[exps[i]])
     *tmp_expcfg.treatcfg.substance = !NULL
     *tmp_expcfg.treatcfg.cal_treat = !NULL
     *tmp_expcfg.treatcfg.sam_treat = !NULL
     *tmp_expcfg.treatcfg.cal_ip = !NULL
     *tmp_expcfg.treatcfg.eval_mode = !NULL
-    (dp_expcfg[exps[i]])=TEMPORARY(tmp_expcfg)
+    (dp_expcfg[exps[i]]) = TEMPORARY(tmp_expcfg)
   ENDFOR
 
 END
@@ -137,7 +137,7 @@ PRO dp_export_treatconfig, sel_exp, PATH=path
   fname = DIALOG_PICKFILE(PATH=path, /WRITE, /OVERWRITE_PROMPT, FILE=datestr+'_dp_treatmthd.info')
   IF STRLEN(fname) EQ 0 THEN RETURN
 
-  sep=STRING(9B)
+  sep = STRING(9B)
 
   OPENW, lun, fname, /GET_LUN
   PRINTF,lun, 'Configuration of cal and sample treatment within IAU_DataProc', FORMAT='(A)'

--- a/DataProc_core/dp_analyse_seq.pro
+++ b/DataProc_core/dp_analyse_seq.pro
@@ -25,8 +25,8 @@ PRO dp_analyse_seq, ID_VECTOR=id_vector, QUIET=quiet, VERBOSE=verbose
 
   COMMON DP_DATA
 
-  IF NOT KEYWORD_SET(verbose) THEN verbose=0
-  IF NOT KEYWORD_SET(id_vector) THEN internal_id_flag=1 ELSE internal_id_flag=0
+  IF NOT KEYWORD_SET(verbose) THEN verbose = 0
+  IF NOT KEYWORD_SET(id_vector) THEN internal_id_flag = 1 ELSE internal_id_flag=0
 
   FOR n=0, N_ELEMENTS(dp_chrom)-1 DO BEGIN ; BEGIN loop over all loaded experiments
     tmp_strct = (dp_expcfg)[n]
@@ -39,17 +39,17 @@ PRO dp_analyse_seq, ID_VECTOR=id_vector, QUIET=quiet, VERBOSE=verbose
     id_tgt = (WHERE(STRUPCASE(sid_name) EQ 'TARGET'))[0] +1
 
     is_cal = LONARR(N_ELEMENTS(id_vector)) ; vector specifying calibration points; 1=cal, 0=other
-    is_cal[WHERE(id_vector EQ id_cal)]=1
+    is_cal[WHERE(id_vector EQ id_cal)] = 1
     is_sam = LONARR(N_ELEMENTS(id_vector)) ; vector specifying calibration points; 1=cal, 0=other
-    is_sam[WHERE(id_vector EQ id_sam OR id_vector EQ id_tgt)]=1
+    is_sam[WHERE(id_vector EQ id_sam OR id_vector EQ id_tgt)] = 1
 
-    ix_init_cal=(WHERE(is_cal EQ 1))[0]
-    ix_term_cal=(WHERE(is_cal EQ 1))[-1]
-    ix_init_sam=(WHERE(is_sam EQ 1))[0]
-    ix_term_sam=(WHERE(is_sam EQ 1))[-1]
+    ix_init_cal = (WHERE(is_cal EQ 1))[0]
+    ix_term_cal = (WHERE(is_cal EQ 1))[-1]
+    ix_init_sam = (WHERE(is_sam EQ 1))[0]
+    ix_term_sam = (WHERE(is_sam EQ 1))[-1]
 
-    IF ix_init_cal GT ix_init_sam THEN miss_1st_cal=1 ELSE miss_1st_cal=0 ; missing first cal?
-    IF ix_term_cal LT ix_term_sam THEN miss_last_cal=2 ELSE miss_last_cal=0 ; missing last cal?
+    IF ix_init_cal GT ix_init_sam THEN miss_1st_cal = 1 ELSE miss_1st_cal=0 ; missing first cal?
+    IF ix_term_cal LT ix_term_sam THEN miss_last_cal = 2 ELSE miss_last_cal=0 ; missing last cal?
 
     n_cbl = N_ELEMENTS(is_cal[WHERE((is_cal[1:-1]-is_cal[0:-2]) GT 0)])
     n_sbl = N_ELEMENTS(is_sam[WHERE((is_sam[1:-1]-is_sam[0:-2]) GT 0)])
@@ -60,24 +60,24 @@ PRO dp_analyse_seq, ID_VECTOR=id_vector, QUIET=quiet, VERBOSE=verbose
                  IF is_cal[0] EQ 1 THEN n_cbl=n_cbl+1 ; correct index shifting method error (cals)
            END
        1:  BEGIN ; fist cal missing
-             IF is_sam[0] EQ 1 THEN n_sbl=n_sbl+1 ; correct index shifting method error (samples)
+             IF is_sam[0] EQ 1 THEN n_sbl = n_sbl+1 ; correct index shifting method error (samples)
            END
       -2:  BEGIN ; last cal missing
-             IF is_cal[0] EQ 1 THEN n_cbl=n_cbl+1 ; correct index shifting method error (cals)
-             miss_last_cal=miss_last_cal-1
+             IF is_cal[0] EQ 1 THEN n_cbl = n_cbl+1 ; correct index shifting method error (cals)
+             miss_last_cal = miss_last_cal-1
            END
       -1:  BEGIN ; initiating and terminating cal missing
-             IF is_cal[0] EQ 1 THEN n_cbl=n_cbl+1 ; correct index shifting method error (cals)
-             miss_last_cal=miss_last_cal-1
+             IF is_cal[0] EQ 1 THEN n_cbl = n_cbl+1 ; correct index shifting method error (cals)
+             miss_last_cal = miss_last_cal-1
            END
     ENDCASE
 
-    ix_vector=LINDGEN(N_ELEMENTS(id_vector))
-    ix_cal=ix_vector[WHERE(is_cal EQ 1)]
-    ix_sam=ix_vector[WHERE(is_sam EQ 1)]
+    ix_vector = LINDGEN(N_ELEMENTS(id_vector))
+    ix_cal = ix_vector[WHERE(is_cal EQ 1)]
+    ix_sam = ix_vector[WHERE(is_sam EQ 1)]
 
-    ix_cbl_start=[]
-    ix_cbl_end=[]
+    ix_cbl_start = []
+    ix_cbl_end = []
     FOR i=0, N_ELEMENTS(is_cal)-2 DO BEGIN
       IF i EQ 0 AND is_cal[i] EQ 1 THEN ix_cbl_start=[ix_cbl_start,ix_vector[i]]
       IF is_cal[i] EQ 0 AND is_cal[i+1] EQ 1 THEN ix_cbl_start=[ix_cbl_start,ix_vector[i+1]]
@@ -85,8 +85,8 @@ PRO dp_analyse_seq, ID_VECTOR=id_vector, QUIET=quiet, VERBOSE=verbose
       IF i EQ N_ELEMENTS(is_cal)-2 AND is_cal[i+1] EQ 1 THEN ix_cbl_end=[ix_cbl_end,ix_vector[i+1]]
     ENDFOR
 
-    ix_sbl_start=[]
-    ix_sbl_end=[]
+    ix_sbl_start = []
+    ix_sbl_end = []
     FOR i=0, N_ELEMENTS(is_sam)-2 DO BEGIN
       IF i EQ 0 AND is_sam[i] EQ 1 THEN ix_sbl_start=[ix_sbl_start,ix_vector[i]]
       IF is_sam[i] EQ 0 AND is_sam[i+1] EQ 1 THEN ix_sbl_start=[ix_sbl_start,ix_vector[i+1]]
@@ -95,7 +95,7 @@ PRO dp_analyse_seq, ID_VECTOR=id_vector, QUIET=quiet, VERBOSE=verbose
     ENDFOR
 
 
-    IF MAX(ix_sbl_end-ix_sbl_start+1)-5 GT -1 THEN ix_max=-1 ELSE ix_max=MAX(ix_sbl_end-ix_sbl_start+1)-6
+    IF MAX(ix_sbl_end-ix_sbl_start+1)-5 GT -1 THEN ix_max = -1 ELSE ix_max=MAX(ix_sbl_end-ix_sbl_start+1)-6
     sam_treat = sam_treat_mthd[0:ix_max]; sam_treat_mthd is common variable, see def_common
 
     tmp_strct.sequence.ID = id_vector ; write information to dp_expcfg structure
@@ -117,9 +117,9 @@ PRO dp_analyse_seq, ID_VECTOR=id_vector, QUIET=quiet, VERBOSE=verbose
     (dp_expcfg)[n] = tmp_strct ; put back into LIST
 
     IF NOT KEYWORD_SET(quiet) THEN BEGIN
-      name_vector=tmp_strct.expinfo.s_name
-      smpls=name_vector[WHERE(is_sam EQ 1)]
-      count=1 ; there is at least one sample...
+      name_vector = tmp_strct.expinfo.s_name
+      smpls = name_vector[WHERE(is_sam EQ 1)]
+      count = 1 ; there is at least one sample...
       FOR s=0, N_ELEMENTS(smpls)-2 DO IF smpls[s+1] NE smpls[s] THEN count=count+1
       IF count GT n_sbl THEN $
         msg=DIALOG_MESSAGE('Found multiple individual samples in one sample block. ' + $

--- a/DataProc_core/dp_analyse_seq.pro
+++ b/DataProc_core/dp_analyse_seq.pro
@@ -26,7 +26,7 @@ PRO dp_analyse_seq, ID_VECTOR=id_vector, QUIET=quiet, VERBOSE=verbose
   COMMON DP_DATA
 
   IF NOT KEYWORD_SET(verbose) THEN verbose = 0
-  IF NOT KEYWORD_SET(id_vector) THEN internal_id_flag = 1 ELSE internal_id_flag=0
+  IF NOT KEYWORD_SET(id_vector) THEN internal_id_flag = 1 ELSE internal_id_flag = 0
 
   FOR n=0, N_ELEMENTS(dp_chrom)-1 DO BEGIN ; BEGIN loop over all loaded experiments
     tmp_strct = (dp_expcfg)[n]
@@ -48,8 +48,8 @@ PRO dp_analyse_seq, ID_VECTOR=id_vector, QUIET=quiet, VERBOSE=verbose
     ix_init_sam = (WHERE(is_sam EQ 1))[0]
     ix_term_sam = (WHERE(is_sam EQ 1))[-1]
 
-    IF ix_init_cal GT ix_init_sam THEN miss_1st_cal = 1 ELSE miss_1st_cal=0 ; missing first cal?
-    IF ix_term_cal LT ix_term_sam THEN miss_last_cal = 2 ELSE miss_last_cal=0 ; missing last cal?
+    IF ix_init_cal GT ix_init_sam THEN miss_1st_cal = 1 ELSE miss_1st_cal = 0 ; missing first cal?
+    IF ix_term_cal LT ix_term_sam THEN miss_last_cal = 2 ELSE miss_last_cal = 0 ; missing last cal?
 
     n_cbl = N_ELEMENTS(is_cal[WHERE((is_cal[1:-1]-is_cal[0:-2]) GT 0)])
     n_sbl = N_ELEMENTS(is_sam[WHERE((is_sam[1:-1]-is_sam[0:-2]) GT 0)])
@@ -95,7 +95,7 @@ PRO dp_analyse_seq, ID_VECTOR=id_vector, QUIET=quiet, VERBOSE=verbose
     ENDFOR
 
 
-    IF MAX(ix_sbl_end-ix_sbl_start+1)-5 GT -1 THEN ix_max = -1 ELSE ix_max=MAX(ix_sbl_end-ix_sbl_start+1)-6
+    IF MAX(ix_sbl_end-ix_sbl_start+1)-5 GT -1 THEN ix_max = -1 ELSE ix_max = MAX(ix_sbl_end-ix_sbl_start+1)-6
     sam_treat = sam_treat_mthd[0:ix_max]; sam_treat_mthd is common variable, see def_common
 
     tmp_strct.sequence.ID = id_vector ; write information to dp_expcfg structure

--- a/DataProc_core/dp_calc_relresp.pro
+++ b/DataProc_core/dp_calc_relresp.pro
@@ -40,7 +40,7 @@ FUNCTION dp_calc_relresp, xdata, ydata, vd_sam, cal_interpol, sel_samtreat, sequ
       BREAK
     ENDIF
   ENDFOR
-  
+
   ; discard samples not bracketed by cals for PRC analyser
   ix_cal = sequence.ix_cal[WHERE(sequence.ix_cal NE -1)]
   ix_init = ix_init[WHERE(ix_init GT ix_cal[0] AND ix_init LT ix_cal[-1])]

--- a/DataProc_core/dp_calc_relresp.pro
+++ b/DataProc_core/dp_calc_relresp.pro
@@ -62,14 +62,14 @@ FUNCTION dp_calc_relresp, xdata, ydata, vd_sam, cal_interpol, sel_samtreat, sequ
 
     'block_last_1':$
       BEGIN
-        blockmean_rR[ix_end]=samples_rR[ix_end]
+        blockmean_rR[ix_end] = samples_rR[ix_end]
       END
 
     'block_last_2':$
       BEGIN
         FOR i=0, n_blocks-1 DO BEGIN
-          s_ix=ix_end[i]-1 ; block of 2: start
-          e_ix=ix_end[i]   ; block of 2: end
+          s_ix = ix_end[i]-1 ; block of 2: start
+          e_ix = ix_end[i]   ; block of 2: end
           blockmean_rR[e_ix] = $
             mean(samples_rR[s_ix:e_ix], /DOUBLE, /NAN)
           block_RSD[e_ix] = $
@@ -80,8 +80,8 @@ FUNCTION dp_calc_relresp, xdata, ydata, vd_sam, cal_interpol, sel_samtreat, sequ
     'block_last_3':$
       BEGIN
         FOR i=0, n_blocks-1 DO BEGIN
-          s_ix=ix_end[i]-2 ; block of 3: start
-          e_ix=ix_end[i]   ; block of 3: end
+          s_ix = ix_end[i]-2 ; block of 3: start
+          e_ix = ix_end[i]   ; block of 3: end
           blockmean_rR[e_ix] = $
             mean(samples_rR[s_ix:e_ix], /DOUBLE, /NAN)
           block_RSD[e_ix] = $
@@ -92,8 +92,8 @@ FUNCTION dp_calc_relresp, xdata, ydata, vd_sam, cal_interpol, sel_samtreat, sequ
     'block_last_4':$
       BEGIN
         FOR i=0, n_blocks-1 DO BEGIN
-          s_ix=ix_end[i]-4 ; block of 4: start
-          e_ix=ix_end[i]   ; block of 4: end
+          s_ix = ix_end[i]-4 ; block of 4: start
+          e_ix = ix_end[i]   ; block of 4: end
           blockmean_rR[e_ix] = $
             mean(samples_rR[s_ix:e_ix], /DOUBLE, /NAN)
           block_RSD[e_ix] = $
@@ -104,8 +104,8 @@ FUNCTION dp_calc_relresp, xdata, ydata, vd_sam, cal_interpol, sel_samtreat, sequ
     ELSE: $ ; default: block mean (also applies if 'individual' is selected)
       BEGIN
         FOR i=0, n_blocks-1 DO BEGIN
-          s_ix=ix_init[i] ; block start
-          e_ix=ix_end[i]  ; block end
+          s_ix = ix_init[i] ; block start
+          e_ix = ix_end[i]  ; block end
           blockmean_rR[e_ix] = $
             mean(samples_rR[s_ix:e_ix], /DOUBLE, /NAN)
           block_RSD[e_ix] = $
@@ -115,7 +115,7 @@ FUNCTION dp_calc_relresp, xdata, ydata, vd_sam, cal_interpol, sel_samtreat, sequ
   ENDCASE
 
 
-  strct={ $
+  strct = { $
           sam_rrsp: samples_rR, $
           block_rrsp: blockmean_rR, $
           block_rsd: block_RSD $

--- a/DataProc_core/dp_call_relresp_calc.pro
+++ b/DataProc_core/dp_call_relresp_calc.pro
@@ -34,7 +34,7 @@ COMMON DP_WIDID
   IF NOT KEYWORD_SET(caltreats) THEN BEGIN
     ID_caltreat = WIDGET_INFO(dp_widid.dp_dataproc, FIND_BY_UNAME='caltreat_dl'); get valid treat options from droplists
     WIDGET_CONTROL, ID_caltreat, GET_VALUE = vd_caltreat
-    w_ne0=WHERE(STRLEN(vd_caltreat) NE 0)
+    w_ne0 = WHERE(STRLEN(vd_caltreat) NE 0)
     IF w_ne0[0] NE -1 THEN vd_caltreat = vd_caltreat[w_ne0]
   ENDIF ELSE vd_caltreat = caltreats
 

--- a/DataProc_core/dp_interpol_cal.pro
+++ b/DataProc_core/dp_interpol_cal.pro
@@ -35,28 +35,28 @@ FUNCTION dp_interpol_cal, xdata, ydata, vd_cal, sel_calip, sel_caltreat, sequenc
               ix_brack_aft = (sequence.ix_end_samblock)[WHERE(sequence.ix_end_samblock NE -1)]+1
               ix_bracks_all = ([ix_brack_bef, ix_brack_aft])[SORT([ix_brack_bef, ix_brack_aft])]
               ix_bracks = ix_bracks_all[uniq(ix_bracks_all)] ; remove double indices if only one cal point between samples
-      
+
               ix_vd_cals = ix_bracks
-              
+
               ; FO 2020-02-29:
               ; bracketing cal scheme might be greatly simplified -
               ; => simply use all cal indices
               ix_vd_cals = (sequence.ix_cal)[WHERE(sequence.ix_cal NE -1)]
-      
+
               IF sequence.miss_1stcal EQ 1 THEN BEGIN
                   ix_bracks = [ix_bracks[0], ix_bracks] ; missing 1st cal: use cal after first sample
                   ix_vd_cals = ix_vd_cals[1:-1]
               ENDIF
-      
+
               IF sequence.miss_lastcal EQ 1 THEN BEGIN
                   ix_bracks = [ix_bracks, ix_bracks[-1]] ; missing last cal: use cal before last sample
                   ix_vd_cals = ix_vd_cals[0:-2]
               ENDIF
-      
-      
+
+
               v = DBLARR(N_ELEMENTS(ix_vd_cals))
               x = DBLARR(N_ELEMENTS(ix_vd_cals))
-      
+
               FOR i=0, N_ELEMENTS(ix_vd_cals)-1 DO BEGIN
                   w = WHERE(vd_cal EQ ix_vd_cals[i])
                   IF w NE -1 THEN BEGIN
@@ -67,36 +67,36 @@ FUNCTION dp_interpol_cal, xdata, ydata, vd_cal, sel_calip, sel_caltreat, sequenc
                       x[i] = !VALUES.D_NAN
                   ENDELSE
               ENDFOR
-                
+
           END
-  
+
       'block_mean': $ ; v and x have to be calculated here
           BEGIN
               ix_calinit = (sequence.ix_init_calblock)[WHERE(sequence.ix_init_calblock NE -1)]
               ix_calend = (sequence.ix_end_calblock)[WHERE(sequence.ix_end_calblock NE -1)]
               ix_saminit = (sequence.ix_init_samblock)[WHERE(sequence.ix_init_samblock NE -1)]
               ix_samend = (sequence.ix_end_samblock)[WHERE(sequence.ix_end_samblock NE -1)]
-      
+
               n_perblock = ix_calend-ix_calinit+1
               n_blocks = N_ELEMENTS(n_perblock)
               n_typical = MEDIAN(n_perblock)
               seq_ix = LINDGEN(N_ELEMENTS(sequence.id))
               seq_ix[WHERE(sequence.id NE id_cal)] = -1
-      
+
               IF (sequence.miss_1stcal NE 1 AND n_perblock[0] GT n_typical) THEN BEGIN ; use typical block length at beginning of series
                   seq_ix[0:ix_calend[0]-n_typical] = -1
                   n_perblock[0] = n_typical
               ENDIF ; missing 1st cal is not treated explicitly -> interpol function is then used to estimate the values that are missing
-      
+
               IF (sequence.miss_lastcal NE 1 AND n_perblock[-1] GT n_typical) THEN BEGIN ; use typical block length at end of series
                   seq_ix[ix_calinit[-1]+n_typical:-1] = -1
                   n_perblock[-1] = n_typical
               ENDIF
-      
+
               ix_vd_cals = seq_ix[WHERE(seq_ix NE -1)]
               v_cals = DBLARR(N_ELEMENTS(ix_vd_cals))
               x_cals = DBLARR(N_ELEMENTS(ix_vd_cals))
-      
+
               FOR i=0, N_ELEMENTS(ix_vd_cals)-1 DO BEGIN
                   w = WHERE(vd_cal EQ ix_vd_cals[i])
                   IF w NE -1 THEN BEGIN
@@ -107,17 +107,17 @@ FUNCTION dp_interpol_cal, xdata, ydata, vd_cal, sel_calip, sel_caltreat, sequenc
                       x_cals[i] = !VALUES.D_NAN
                   ENDELSE
               ENDFOR
-      
+
               v = DBLARR(n_blocks)
               x = DBLARR(n_blocks)
-      
+
               FOR i=0, n_blocks-1 DO BEGIN
                   v[i] = mean(v_cals[(TOTAL(n_perblock[0:i])-n_perblock[i]):(TOTAL(n_perblock[0:i])-1)], /DOUBLE, /NAN)
                   x[i] = mean(x_cals[(TOTAL(n_perblock[0:i])-n_perblock[i]):(TOTAL(n_perblock[0:i])-1)], /DOUBLE, /NAN)
                   calblock_rsd[ix_calend[i]] = stddev(v_cals[(TOTAL(n_perblock[0:i])-n_perblock[i]):(TOTAL(n_perblock[0:i])-1)], /DOUBLE, /NAN)/v[i]
               ENDFOR
           END
-  
+
       'preceding': $ ; determine cal indices...
           BEGIN
               ix_init = (sequence.ix_init_calblock)[WHERE(sequence.ix_init_calblock NE -1)]
@@ -127,7 +127,7 @@ FUNCTION dp_interpol_cal, xdata, ydata, vd_cal, sel_calip, sel_caltreat, sequenc
               n_perblock = ix_end-ix_init+1
               n_typical = MEDIAN(n_perblock)
               ix_prec = ix_brack_bef
-      
+
               IF sequence.miss_1stcal EQ 1 THEN ix_prec = [ix_prec[0], ix_prec]
               IF sequence.miss_lastcal EQ 1 THEN ix_prec = [ix_prec, ix_prec[-1]] $
                   ELSE BEGIN ; last cal not missing; check last block length and select a point that would correspond...
@@ -135,11 +135,11 @@ FUNCTION dp_interpol_cal, xdata, ydata, vd_cal, sel_calip, sel_caltreat, sequenc
                       ix_prec = [ix_brack_bef, (ix_brack_aft[-1]+n_typical-1)] $
                         ELSE ix_prec = [ix_brack_bef, ix_brack_aft[-1]]
                   ENDELSE
-      
+
               ix_vd_cals = ix_prec
               v = DBLARR(N_ELEMENTS(ix_vd_cals))
               x = DBLARR(N_ELEMENTS(ix_vd_cals))
-      
+
               FOR i=0, N_ELEMENTS(ix_vd_cals)-1 DO BEGIN
                   w = WHERE(vd_cal EQ ix_vd_cals[i], nw)
                   IF nw NE 0 THEN BEGIN
@@ -150,10 +150,10 @@ FUNCTION dp_interpol_cal, xdata, ydata, vd_cal, sel_calip, sel_caltreat, sequenc
                       x[i] = !VALUES.D_NAN
                   ENDELSE
               ENDFOR
-      
+
               IF sequence.miss_1stcal THEN x[0] = xdata[0]
               IF sequence.miss_lastcal THEN x[-1] = xdata[-1]
-  
+
         END
 
   ENDCASE
@@ -192,7 +192,7 @@ FUNCTION dp_interpol_cal, xdata, ydata, vd_cal, sel_calip, sel_caltreat, sequenc
             ENDIF $
                 ELSE vout = DBLARR(N_ELEMENTS(xdata))*!Values.D_NAN
         END
-      
+
       'running_mean_p2p': $ ;edit T.W. 20191006
         BEGIN
             V = ts_smooth(V, 3)

--- a/DataProc_core/dp_wid_dataproc_ini.pro
+++ b/DataProc_core/dp_wid_dataproc_ini.pro
@@ -107,7 +107,7 @@ PRO dp_wid_dataproc_handle, event
     'calc_all' : $
       BEGIN
         quest=DIALOG_MESSAGE('Use loaded cal/sample treatment config if available?', /QUESTION)
-        IF quest EQ 'Yes' THEN current = 0 ELSE current=1
+        IF quest EQ 'Yes' THEN current = 0 ELSE current = 1
         dp_call_relresp_calc, sel_caltreat, sel_samtreat, sel_calip, OVERWRITE=ovwr, $
                               CURRENT=current, EVAL_MODE=eval_mode, VERBOSE=verbose
         dp_wid_dataproc_upd, event
@@ -119,7 +119,7 @@ PRO dp_wid_dataproc_handle, event
       BEGIN
         IF N_ELEMENTS(dp_chrom) GT 1 THEN BEGIN
           quest=DIALOG_MESSAGE('Precision: Load for selected experiment only?', /QUESTION, /CANCEL)
-          IF quest EQ 'No' THEN sel_only = 0 ELSE sel_only=1
+          IF quest EQ 'No' THEN sel_only = 0 ELSE sel_only = 1
           IF quest EQ 'Cancel' THEN RETURN
         ENDIF
         prc_strct=dp_read_instrprc(sel_exp, chromlist[sel_exp], substlist, $
@@ -132,7 +132,7 @@ PRO dp_wid_dataproc_handle, event
       BEGIN
         IF N_ELEMENTS(dp_chrom) GT 1 THEN BEGIN
           quest=DIALOG_MESSAGE('Cal MRs: Load for selected experiment only?', /QUESTION, /CANCEL)
-          IF quest EQ 'No' THEN sel_only = 0 ELSE sel_only=1
+          IF quest EQ 'No' THEN sel_only = 0 ELSE sel_only = 1
           IF quest EQ 'Cancel' THEN RETURN
         ENDIF
         mrs_strct=dp_read_calmrs(PATH=path_wd, VERBOSE=verbose)
@@ -144,7 +144,7 @@ PRO dp_wid_dataproc_handle, event
       BEGIN
         IF N_ELEMENTS(dp_chrom) GT 1 THEN BEGIN
           quest=DIALOG_MESSAGE('Target MRs: Load for selected experiment only?', /QUESTION, /CANCEL)
-          IF quest EQ 'No' THEN sel_only = 0 ELSE sel_only=1
+          IF quest EQ 'No' THEN sel_only = 0 ELSE sel_only = 1
           IF quest EQ 'Cancel' THEN RETURN
         ENDIF
         tgt_strct=dp_read_tgtmrs(PATH=path_wd, VERBOSE=verbose)
@@ -157,7 +157,7 @@ PRO dp_wid_dataproc_handle, event
         sel_only = 1
         IF N_ELEMENTS(dp_chrom) GT 1 THEN BEGIN
           quest=DIALOG_MESSAGE('Load for selected experiment only?', /QUESTION, /CANCEL)
-          IF quest EQ 'No' THEN sel_only = 0 ELSE sel_only=1
+          IF quest EQ 'No' THEN sel_only = 0 ELSE sel_only = 1
           IF quest EQ 'Cancel' THEN RETURN
         ENDIF
         dp_read_treatcfg, sel_exp, SEL_ONLY=sel_only, VERBOSE=verbose
@@ -171,7 +171,7 @@ PRO dp_wid_dataproc_handle, event
         IF N_ELEMENTS(dp_chrom) GT 1 THEN BEGIN
           quest=DIALOG_MESSAGE('Load for selected experiment only?', /QUESTION, /CANCEL)
           IF quest EQ 'Cancel' THEN RETURN
-          IF quest EQ 'No' THEN sel_only = 0 ELSE sel_only=1
+          IF quest EQ 'No' THEN sel_only = 0 ELSE sel_only = 1
         ENDIF
         dp_read_cocorrparms, sel_exp, SEL_ONLY=sel_only, PATH=path_wd, $
                             DEF_FILE=def_file, VERBOSE=verbose
@@ -184,7 +184,7 @@ PRO dp_wid_dataproc_handle, event
         IF N_ELEMENTS(dp_chrom) GT 1 THEN BEGIN
           quest=DIALOG_MESSAGE('Remove for selected experiment only?', /QUESTION, /CANCEL)
           IF quest EQ 'Cancel' THEN RETURN
-          IF quest EQ 'No' THEN sel_only = 0 ELSE sel_only=1
+          IF quest EQ 'No' THEN sel_only = 0 ELSE sel_only = 1
         ENDIF
         dp_remv_instrprc, sel_exp, SEL_ONLY=sel_only, /LOUD
       END
@@ -194,7 +194,7 @@ PRO dp_wid_dataproc_handle, event
         IF N_ELEMENTS(dp_chrom) GT 1 THEN BEGIN
           quest=DIALOG_MESSAGE('Remove for selected experiment only?', /QUESTION, /CANCEL)
           IF quest EQ 'Cancel' THEN RETURN
-          IF quest EQ 'No' THEN sel_only = 0 ELSE sel_only=1
+          IF quest EQ 'No' THEN sel_only = 0 ELSE sel_only = 1
         ENDIF
         dp_remv_calmrs, sel_exp, SEL_ONLY=sel_only, /LOUD
       END
@@ -204,7 +204,7 @@ PRO dp_wid_dataproc_handle, event
         IF N_ELEMENTS(dp_chrom) GT 1 THEN BEGIN
           quest=DIALOG_MESSAGE('Remove for selected experiment only?', /QUESTION, /CANCEL)
           IF quest EQ 'Cancel' THEN RETURN
-          IF quest EQ 'No' THEN sel_only = 0 ELSE sel_only=1
+          IF quest EQ 'No' THEN sel_only = 0 ELSE sel_only = 1
         ENDIF
         dp_remv_tgtmrs, sel_exp, SEL_ONLY=sel_only, /LOUD
       END
@@ -214,7 +214,7 @@ PRO dp_wid_dataproc_handle, event
         IF N_ELEMENTS(dp_chrom) GT 1 THEN BEGIN
           quest=DIALOG_MESSAGE('Remove for selected experiment only?', /QUESTION, /CANCEL)
           IF quest EQ 'Cancel' THEN RETURN
-          IF quest EQ 'No' THEN sel_only = 0 ELSE sel_only=1
+          IF quest EQ 'No' THEN sel_only = 0 ELSE sel_only = 1
         ENDIF
         dp_remv_treatcfg, sel_exp, SEL_ONLY=sel_only, /LOUD
         dp_call_relresp_calc, 0, 0, 0, VERBOSE=verbose
@@ -226,7 +226,7 @@ PRO dp_wid_dataproc_handle, event
         IF N_ELEMENTS(dp_chrom) GT 1 THEN BEGIN
           quest=DIALOG_MESSAGE('Remove for selected experiment only?', /QUESTION, /CANCEL)
           IF quest EQ 'Cancel' THEN RETURN
-          IF quest EQ 'No' THEN sel_only = 0 ELSE sel_only=1
+          IF quest EQ 'No' THEN sel_only = 0 ELSE sel_only = 1
         ENDIF
         dp_remv_cocorr, sel_exp, SEL_ONLY=sel_only, /LOUD
         dp_call_relresp_calc, sel_caltreat, sel_samtreat, sel_calip, VERBOSE=verbose

--- a/DataProc_core/dp_wid_dataproc_ini.pro
+++ b/DataProc_core/dp_wid_dataproc_ini.pro
@@ -66,8 +66,8 @@ PRO dp_wid_dataproc_handle, event
       BEGIN
         WIDGET_CONTROL, ID_caltreat, GET_VALUE=dl_val
         IF dl_val[sel_caltreat] EQ '' THEN BEGIN
-          !NULL=DIALOG_MESSAGE('Please select a valid option.')
-          sel_caltreat=0
+          !NULL = DIALOG_MESSAGE('Please select a valid option.')
+          sel_caltreat = 0
           WIDGET_CONTROL, ID_caltreat, SET_DROPLIST_SELECT=sel_caltreat
         ENDIF
       END
@@ -76,8 +76,8 @@ PRO dp_wid_dataproc_handle, event
         BEGIN
         WIDGET_CONTROL, ID_samtreat, GET_VALUE=dl_val
         IF dl_val[sel_samtreat] EQ '' THEN BEGIN
-          !NULL=DIALOG_MESSAGE('Please select a valid option.')
-          sel_samtreat=0
+          !NULL = DIALOG_MESSAGE('Please select a valid option.')
+          sel_samtreat = 0
           WIDGET_CONTROL, ID_samtreat, SET_DROPLIST_SELECT=sel_caltreat
         ENDIF
       END
@@ -107,7 +107,7 @@ PRO dp_wid_dataproc_handle, event
     'calc_all' : $
       BEGIN
         quest=DIALOG_MESSAGE('Use loaded cal/sample treatment config if available?', /QUESTION)
-        IF quest EQ 'Yes' THEN current=0 ELSE current=1
+        IF quest EQ 'Yes' THEN current = 0 ELSE current=1
         dp_call_relresp_calc, sel_caltreat, sel_samtreat, sel_calip, OVERWRITE=ovwr, $
                               CURRENT=current, EVAL_MODE=eval_mode, VERBOSE=verbose
         dp_wid_dataproc_upd, event
@@ -119,7 +119,7 @@ PRO dp_wid_dataproc_handle, event
       BEGIN
         IF N_ELEMENTS(dp_chrom) GT 1 THEN BEGIN
           quest=DIALOG_MESSAGE('Precision: Load for selected experiment only?', /QUESTION, /CANCEL)
-          IF quest EQ 'No' THEN sel_only=0 ELSE sel_only=1
+          IF quest EQ 'No' THEN sel_only = 0 ELSE sel_only=1
           IF quest EQ 'Cancel' THEN RETURN
         ENDIF
         prc_strct=dp_read_instrprc(sel_exp, chromlist[sel_exp], substlist, $
@@ -132,7 +132,7 @@ PRO dp_wid_dataproc_handle, event
       BEGIN
         IF N_ELEMENTS(dp_chrom) GT 1 THEN BEGIN
           quest=DIALOG_MESSAGE('Cal MRs: Load for selected experiment only?', /QUESTION, /CANCEL)
-          IF quest EQ 'No' THEN sel_only=0 ELSE sel_only=1
+          IF quest EQ 'No' THEN sel_only = 0 ELSE sel_only=1
           IF quest EQ 'Cancel' THEN RETURN
         ENDIF
         mrs_strct=dp_read_calmrs(PATH=path_wd, VERBOSE=verbose)
@@ -144,7 +144,7 @@ PRO dp_wid_dataproc_handle, event
       BEGIN
         IF N_ELEMENTS(dp_chrom) GT 1 THEN BEGIN
           quest=DIALOG_MESSAGE('Target MRs: Load for selected experiment only?', /QUESTION, /CANCEL)
-          IF quest EQ 'No' THEN sel_only=0 ELSE sel_only=1
+          IF quest EQ 'No' THEN sel_only = 0 ELSE sel_only=1
           IF quest EQ 'Cancel' THEN RETURN
         ENDIF
         tgt_strct=dp_read_tgtmrs(PATH=path_wd, VERBOSE=verbose)
@@ -154,10 +154,10 @@ PRO dp_wid_dataproc_handle, event
     ;*****************************
     'load_treatcfg' : $
       BEGIN
-        sel_only=1
+        sel_only = 1
         IF N_ELEMENTS(dp_chrom) GT 1 THEN BEGIN
           quest=DIALOG_MESSAGE('Load for selected experiment only?', /QUESTION, /CANCEL)
-          IF quest EQ 'No' THEN sel_only=0 ELSE sel_only=1
+          IF quest EQ 'No' THEN sel_only = 0 ELSE sel_only=1
           IF quest EQ 'Cancel' THEN RETURN
         ENDIF
         dp_read_treatcfg, sel_exp, SEL_ONLY=sel_only, VERBOSE=verbose
@@ -167,11 +167,11 @@ PRO dp_wid_dataproc_handle, event
     ;*****************************
     'load_co_corr' : $
       BEGIN
-        sel_only=1
+        sel_only = 1
         IF N_ELEMENTS(dp_chrom) GT 1 THEN BEGIN
           quest=DIALOG_MESSAGE('Load for selected experiment only?', /QUESTION, /CANCEL)
           IF quest EQ 'Cancel' THEN RETURN
-          IF quest EQ 'No' THEN sel_only=0 ELSE sel_only=1
+          IF quest EQ 'No' THEN sel_only = 0 ELSE sel_only=1
         ENDIF
         dp_read_cocorrparms, sel_exp, SEL_ONLY=sel_only, PATH=path_wd, $
                             DEF_FILE=def_file, VERBOSE=verbose
@@ -184,7 +184,7 @@ PRO dp_wid_dataproc_handle, event
         IF N_ELEMENTS(dp_chrom) GT 1 THEN BEGIN
           quest=DIALOG_MESSAGE('Remove for selected experiment only?', /QUESTION, /CANCEL)
           IF quest EQ 'Cancel' THEN RETURN
-          IF quest EQ 'No' THEN sel_only=0 ELSE sel_only=1
+          IF quest EQ 'No' THEN sel_only = 0 ELSE sel_only=1
         ENDIF
         dp_remv_instrprc, sel_exp, SEL_ONLY=sel_only, /LOUD
       END
@@ -194,7 +194,7 @@ PRO dp_wid_dataproc_handle, event
         IF N_ELEMENTS(dp_chrom) GT 1 THEN BEGIN
           quest=DIALOG_MESSAGE('Remove for selected experiment only?', /QUESTION, /CANCEL)
           IF quest EQ 'Cancel' THEN RETURN
-          IF quest EQ 'No' THEN sel_only=0 ELSE sel_only=1
+          IF quest EQ 'No' THEN sel_only = 0 ELSE sel_only=1
         ENDIF
         dp_remv_calmrs, sel_exp, SEL_ONLY=sel_only, /LOUD
       END
@@ -204,7 +204,7 @@ PRO dp_wid_dataproc_handle, event
         IF N_ELEMENTS(dp_chrom) GT 1 THEN BEGIN
           quest=DIALOG_MESSAGE('Remove for selected experiment only?', /QUESTION, /CANCEL)
           IF quest EQ 'Cancel' THEN RETURN
-          IF quest EQ 'No' THEN sel_only=0 ELSE sel_only=1
+          IF quest EQ 'No' THEN sel_only = 0 ELSE sel_only=1
         ENDIF
         dp_remv_tgtmrs, sel_exp, SEL_ONLY=sel_only, /LOUD
       END
@@ -214,7 +214,7 @@ PRO dp_wid_dataproc_handle, event
         IF N_ELEMENTS(dp_chrom) GT 1 THEN BEGIN
           quest=DIALOG_MESSAGE('Remove for selected experiment only?', /QUESTION, /CANCEL)
           IF quest EQ 'Cancel' THEN RETURN
-          IF quest EQ 'No' THEN sel_only=0 ELSE sel_only=1
+          IF quest EQ 'No' THEN sel_only = 0 ELSE sel_only=1
         ENDIF
         dp_remv_treatcfg, sel_exp, SEL_ONLY=sel_only, /LOUD
         dp_call_relresp_calc, 0, 0, 0, VERBOSE=verbose
@@ -226,7 +226,7 @@ PRO dp_wid_dataproc_handle, event
         IF N_ELEMENTS(dp_chrom) GT 1 THEN BEGIN
           quest=DIALOG_MESSAGE('Remove for selected experiment only?', /QUESTION, /CANCEL)
           IF quest EQ 'Cancel' THEN RETURN
-          IF quest EQ 'No' THEN sel_only=0 ELSE sel_only=1
+          IF quest EQ 'No' THEN sel_only = 0 ELSE sel_only=1
         ENDIF
         dp_remv_cocorr, sel_exp, SEL_ONLY=sel_only, /LOUD
         dp_call_relresp_calc, sel_caltreat, sel_samtreat, sel_calip, VERBOSE=verbose
@@ -261,9 +261,9 @@ PRO dp_wid_dataproc_handle, event
     ;*****************************
     'show_svolselect' : $
       BEGIN
-        s_vol_select=((dp_expcfg[sel_exp]).expinfo.s_vol_select)[0]
+        s_vol_select = ((dp_expcfg[sel_exp]).expinfo.s_vol_select)[0]
         s_vol_origins=['Pressure Difference', 'Mass Flow Controller']
-        info='Sample volume determined by: '+s_vol_origins[s_vol_select]
+        info = 'Sample volume determined by: '+s_vol_origins[s_vol_select]
         !NULL=DIALOG_MESSAGE(info, /INFORMATION)
       END
     ;*****************************
@@ -364,20 +364,20 @@ PRO dp_wid_dataproc_ini
     EDL=WIDGET_DROPLIST(subbase3, VALUE=substlist[0], UNAME='subst_dl', /DYNAMIC_RESIZE, /ALIGN_LEFT)
     SEP=WIDGET_LABEL(subbase3, VALUE='   ')
 
-  edit_tab=WIDGET_TAB(dpbase)
+  edit_tab = WIDGET_TAB(dpbase)
     subbase1=WIDGET_BASE(edit_tab, col=3, TITLE='Selected Data: Edit...')
       TXT=WIDGET_LABEL(subbase1, VALUE='CAL Treat Mthd:       ', /ALIGN_LEFT)
-      caltreatvals=((dp_expcfg)[0]).sequence.cal_treat
+      caltreatvals = ((dp_expcfg)[0]).sequence.cal_treat
       ID_caltreat=WIDGET_DROPLIST(subbase1, VALUE=caltreatvals, UNAME='caltreat_dl', /DYNAMIC_RESIZE, /ALIGN_LEFT)
       SEP=WIDGET_LABEL(subbase1, VALUE='   ')
       TXT=WIDGET_LABEL(subbase1, VALUE='SAM Treat Mthd:       ', /ALIGN_LEFT)
-      samtreatvals=((dp_expcfg)[0]).sequence.sam_treat
+      samtreatvals = ((dp_expcfg)[0]).sequence.sam_treat
       ID_samtreat=WIDGET_DROPLIST(subbase1, VALUE=samtreatvals, UNAME='samtreat_dl', /DYNAMIC_RESIZE, /ALIGN_LEFT)
       ID_mw_etype=WIDGET_INFO(dp_widid.dp_mainwid, FIND_BY_UNAME='exptype_dl')
       IF WIDGET_INFO(ID_mw_etype, /DROPLIST_SELECT) EQ 1 THEN $ ; if continous, select individual sample treatment
         WIDGET_CONTROL, ID_samtreat, SET_DROPLIST_SELECT=(WHERE(sam_treat_mthd EQ 'individual'))[0]
       TXT=WIDGET_LABEL(subbase1, VALUE='CAL Interpol Mthd:    ', /ALIGN_LEFT)
-      interpolvals=cal_ip_mthd
+      interpolvals = cal_ip_mthd
       ID_calip=WIDGET_DROPLIST(subbase1, VALUE=interpolvals, UNAME='calip_dl', /DYNAMIC_RESIZE, /ALIGN_LEFT)
       SEP=WIDGET_LABEL(subbase1, VALUE='   ')
       SEP=WIDGET_LABEL(subbase1, VALUE='   ')
@@ -415,14 +415,14 @@ PRO dp_wid_dataproc_ini
   dp_widid.dp_dataproc = dpbase
   WIDGET_CONTROL, dpbase, /REALIZE
 
-  sel_exp=0       ; update droplist settings in case an experiment is restored
-  sel_subst=0     ; and settings are not default.
-  cal_ip=(dp_chrom[sel_exp]).subst[sel_subst].rres.cal_ip_mthd
-  caltreat=(dp_chrom[sel_exp]).subst[sel_subst].rres.cal_treat
-  samtreat=(dp_chrom[sel_exp]).subst[sel_subst].rres.sam_treat
-  new_sel_calip=(WHERE(cal_ip_mthd EQ cal_ip))[0]
-  new_sel_caltreat=(WHERE(cal_treat_mthd EQ caltreat))[0]
-  new_sel_samtreat=(WHERE(sam_treat_mthd EQ samtreat))[0]
+  sel_exp = 0       ; update droplist settings in case an experiment is restored
+  sel_subst = 0     ; and settings are not default.
+  cal_ip = (dp_chrom[sel_exp]).subst[sel_subst].rres.cal_ip_mthd
+  caltreat = (dp_chrom[sel_exp]).subst[sel_subst].rres.cal_treat
+  samtreat = (dp_chrom[sel_exp]).subst[sel_subst].rres.sam_treat
+  new_sel_calip = (WHERE(cal_ip_mthd EQ cal_ip))[0]
+  new_sel_caltreat = (WHERE(cal_treat_mthd EQ caltreat))[0]
+  new_sel_samtreat = (WHERE(sam_treat_mthd EQ samtreat))[0]
   WIDGET_CONTROL, ID_calip, SET_DROPLIST_SELECT=new_sel_calip
   WIDGET_CONTROL, ID_caltreat, SET_DROPLIST_SELECT=new_sel_caltreat
   WIDGET_CONTROL, ID_samtreat, SET_DROPLIST_SELECT=new_sel_samtreat

--- a/DataProc_core/dp_wid_dataproc_upd.pro
+++ b/DataProc_core/dp_wid_dataproc_upd.pro
@@ -22,12 +22,12 @@ COMMON dp_data
     (uname_sel EQ 'exp_dl') OR (uname_sel EQ 'chg_substnames') : $
       BEGIN ; selected experiment changed, update droplists: cal treat, sam treat, substances
         IF ((dp_chrom[sel_exp]).subst[sel_subst].rres.cal_treat)[0] NE '' THEN BEGIN
-          cal_ip=(dp_chrom[sel_exp]).subst[sel_subst].rres.cal_ip_mthd
-          caltreat=(dp_chrom[sel_exp]).subst[sel_subst].rres.cal_treat
-          samtreat=(dp_chrom[sel_exp]).subst[sel_subst].rres.sam_treat
-          new_sel_calip=(WHERE(cal_ip_mthd EQ cal_ip))[0]
-          new_sel_caltreat=(WHERE(cal_treat_mthd EQ caltreat))[0]
-          new_sel_samtreat=(WHERE(sam_treat_mthd EQ samtreat))[0]
+          cal_ip = (dp_chrom[sel_exp]).subst[sel_subst].rres.cal_ip_mthd
+          caltreat = (dp_chrom[sel_exp]).subst[sel_subst].rres.cal_treat
+          samtreat = (dp_chrom[sel_exp]).subst[sel_subst].rres.sam_treat
+          new_sel_calip = (WHERE(cal_ip_mthd EQ cal_ip))[0]
+          new_sel_caltreat = (WHERE(cal_treat_mthd EQ caltreat))[0]
+          new_sel_samtreat = (WHERE(sam_treat_mthd EQ samtreat))[0]
           WIDGET_CONTROL, ID_calip, SET_DROPLIST_SELECT=new_sel_calip
           WIDGET_CONTROL, ID_caltreat, SET_DROPLIST_SELECT=new_sel_caltreat
           WIDGET_CONTROL, ID_samtreat, SET_DROPLIST_SELECT=new_sel_samtreat
@@ -39,12 +39,12 @@ COMMON dp_data
     ELSE: $
       BEGIN
         IF ((dp_chrom[sel_exp]).subst[sel_subst].rres.cal_treat)[0] NE '' THEN BEGIN
-          cal_ip=(dp_chrom[sel_exp]).subst[sel_subst].rres.cal_ip_mthd
-          caltreat=(dp_chrom[sel_exp]).subst[sel_subst].rres.cal_treat
-          samtreat=(dp_chrom[sel_exp]).subst[sel_subst].rres.sam_treat
-          new_sel_calip=(WHERE(cal_ip_mthd EQ cal_ip))[0]
-          new_sel_caltreat=(WHERE(cal_treat_mthd EQ caltreat))[0]
-          new_sel_samtreat=(WHERE(sam_treat_mthd EQ samtreat))[0]
+          cal_ip = (dp_chrom[sel_exp]).subst[sel_subst].rres.cal_ip_mthd
+          caltreat = (dp_chrom[sel_exp]).subst[sel_subst].rres.cal_treat
+          samtreat = (dp_chrom[sel_exp]).subst[sel_subst].rres.sam_treat
+          new_sel_calip = (WHERE(cal_ip_mthd EQ cal_ip))[0]
+          new_sel_caltreat = (WHERE(cal_treat_mthd EQ caltreat))[0]
+          new_sel_samtreat = (WHERE(sam_treat_mthd EQ samtreat))[0]
           WIDGET_CONTROL, ID_calip, SET_DROPLIST_SELECT=new_sel_calip
           WIDGET_CONTROL, ID_caltreat, SET_DROPLIST_SELECT=new_sel_caltreat
           WIDGET_CONTROL, ID_samtreat, SET_DROPLIST_SELECT=new_sel_samtreat

--- a/IAU_DataProc.pro
+++ b/IAU_DataProc.pro
@@ -331,7 +331,7 @@ END
 ;
 ; 2016-10-27 (v1.11)
 ; - code clean-up, added some comments.
-; - added dynamic determination of IDs (e.g. Cal=3) based on indices in common variable sid_name.
+; - added dynamic determination of IDs (e.g. Cal = 3) based on indices in common variable sid_name.
 ; - added suffix 'iaudp' if a reportfile is generated for selected experiment and substance.
 ; - added mean sample block rsd to report file header.
 ; - rearranged main widget.

--- a/IAU_DataProc.pro
+++ b/IAU_DataProc.pro
@@ -16,17 +16,18 @@ PRO IAU_DataProc
 
   COMMON dp_data
 
-  dp_def_common, '1.30' ; string == version
+  dp_def_common, '1.31' ; string == version
 
   path_wd = 'D:\'
+;  path_wd = 'D:\PROGRAMMING\IDL\dev_debugging\IAU_DataProc\'
 
-  error_handler_IO = 0
+  error_handler_IO = 1
 
   dp_wid_main_ini
 
-;  Outdir = 'D:\PROGRAMMING\debugging\iau_dataproc\rt'
-;  sfile = 'D:\PROGRAMMING\IDL_WD\IAU_DataProc_1X\IAU_DataProc_v130.sav'
-;  MAKE_RT, 'IAU_DataProc_v130', Outdir, SAVEFILE=sfile, /OVERWRITE
+;  Outdir = 'D:\PROGRAMMING\IDL\VM\_tmp'
+;  sfile = 'D:\PROGRAMMING\IDL\VM\_tmp\IAU_DataProc_v1X\IAU_DataProc.sav'
+;  MAKE_RT, 'IAU_DataProc', Outdir, SAVEFILE=sfile, /OVERWRITE
 
 END
 ;------------------------------------------------------------------------------------------------------------------------

--- a/Load_Data/dp_call_expinfo.pro
+++ b/Load_Data/dp_call_expinfo.pro
@@ -55,8 +55,8 @@
 PRO dp_call_expinfo, FNAME=fname, OVERWRITE=overwrite, VERBOSE=verbose
 
   dp_refr_status, MESSAGE='loading exp-info...'
-  IF NOT KEYWORD_SET(verbose) THEN verbose=0
-  IF NOT KEYWORD_SET(overwrite) THEN overwrite=0
+  IF NOT KEYWORD_SET(verbose) THEN verbose = 0
+  IF NOT KEYWORD_SET(overwrite) THEN overwrite = 0
   IF verbose THEN print, 'beginning to load experiment-info(s)...'
 
   COMMON DP_DATA
@@ -75,7 +75,7 @@ PRO dp_call_expinfo, FNAME=fname, OVERWRITE=overwrite, VERBOSE=verbose
     RETURN
   ENDIF
 
-  n_files=N_ELEMENTS(fname)
+  n_files = N_ELEMENTS(fname)
   IF N_ELEMENTS(dp_chrom) NE n_files THEN BEGIN
     msg=DIALOG_MESSAGE('Please select the correct number of ExpInfo-files.', /ERROR)
     dp_refr_status, /CLEAR
@@ -89,9 +89,9 @@ PRO dp_call_expinfo, FNAME=fname, OVERWRITE=overwrite, VERBOSE=verbose
     CASE 1 OF
       (instr EQ 'Lab_BenchTOF' OR instr EQ 'Lab_QP/SFMS'): $
         BEGIN
-          def_offset=2 ; old header size up to 2016-11; use header_size tag in header for newer files
-          sep=';'
-          name='ChromInfo'
+          def_offset = 2 ; old header size up to 2016-11; use header_size tag in header for newer files
+          sep = ';'
+          name = 'ChromInfo'
           search_tags=['opr','Comment','rv_vol','Fname','Run_No','Sample_Name','s_date','PosLat','PosLon','PosAlt', $
                        'Sample_ID','s_vol','Vol0','Vol1','rv_dp','MFC.flow.set','MFC.cts','Ts_cldhd','Te_cldhd', $
                        'enrich_start','enrich_stop','dt','use']
@@ -101,9 +101,9 @@ PRO dp_call_expinfo, FNAME=fname, OVERWRITE=overwrite, VERBOSE=verbose
 
       (instr EQ 'FASTOF'): $
         BEGIN
-          def_offset=5
-          sep=STRING(9b)
-          name=''
+          def_offset = 5
+          sep = STRING(9b)
+          name = ''
           search_tags=['Operator','com','rv_vol','fname','Run_No','Sample_Name','s_date','s_lat','s_lon','s_alt',$
                        'Sample_ID','s_vol','p0[hPa]', 'p1[hPa]','dp[hPa]','F.Set[mL]','Counter[mL]','TCH_p0', $
                        'TCH_p1','t_p0','t_p1','dt','use']
@@ -113,9 +113,9 @@ PRO dp_call_expinfo, FNAME=fname, OVERWRITE=overwrite, VERBOSE=verbose
 
       (instr EQ 'GhOST_MS' OR instr EQ 'GhOST_ECD'): $
         BEGIN
-          def_offset=0
-          sep=STRING(9b)
-          name='Chrom'
+          def_offset = 0
+          sep = STRING(9b)
+          name = 'Chrom'
           search_tags=['opr','com','rv_vol','fname','nr','s_name','s_date','s_lat','s_lon','s_alt','s_id','s_vol','p0', $
                        'p1','dp','mfc_flow','mfc_vol','Ts_cldhd','Te_cldhd','ts','te','dt','use']
           import = dp_read_expinfofile(fname[n], n, SEP=sep, DEF_OFFSET=def_offset, NAME=name, $
@@ -124,9 +124,9 @@ PRO dp_call_expinfo, FNAME=fname, OVERWRITE=overwrite, VERBOSE=verbose
 
       (instr EQ 'AED'): $
         BEGIN
-          def_offset=9
-          sep=';'
-          name='expinfo'
+          def_offset = 9
+          sep = ';'
+          name = 'expinfo'
           search_tags=['opr','Comment','rv_vol','Fname','Run_No','Sample_Name','s_date','PosLat','PosLon','PosAlt','Sample_ID','s_vol','rv_ps', $
                        'rv_pe','rv_dp','mfc_flow','SVol.ml','Ts_cldhd','Te_cldhd','ts','te','dt','Use']
           import = dp_read_expinfofile(fname[n], n, SEP=sep, DEF_OFFSET=def_offset, NAME=name, $
@@ -136,9 +136,9 @@ PRO dp_call_expinfo, FNAME=fname, OVERWRITE=overwrite, VERBOSE=verbose
       (instr EQ 'GHGGC_ECD/FID'): $
         BEGIN
           import = !NULL
-          def_offset=7
-          sep=';'
-          name='expinfo'
+          def_offset = 7
+          sep = ';'
+          name = 'expinfo'
           search_tags=['OPERATOR','SAMPLER','FLIGHT','FNAME','NR','S_NAME','CHEMSTATION_START','LAT_dgr_mean',$
                        'LON_dgr_mean','ALT_pstatic_hPa','S_ID','s_vol','P0','P1','dp','mfc_flow','mfc_vol','Ts_cldhd',$
                        'Te_cldhd','t0_collection','t1_collection','dt','USE']
@@ -204,24 +204,24 @@ PRO dp_call_expinfo, FNAME=fname, OVERWRITE=overwrite, VERBOSE=verbose
     ENDIF ELSE dp_expcfg.add, tmp_strct ; add elements to the list
 
     use_def = import.use
-    tmp_chrom=(dp_chrom[n])
-    n_subst=N_ELEMENTS(tmp_chrom[0].subst.name)
+    tmp_chrom = (dp_chrom[n])
+    n_subst = N_ELEMENTS(tmp_chrom[0].subst.name)
     FOR k=0, n_subst-1 DO tmp_chrom.subst[k].rres.use_flag = use_def  ; overwrite use_flag in rres strct
-    (dp_chrom[n])=tmp_chrom
+    (dp_chrom[n]) = tmp_chrom
 
   ENDFOR ; loop over selected files
 
 
   IF overwrite THEN BEGIN ; delete results if previous expinfo is overwritten by the current operation
-    ref_rres=create_ref_rres()
+    ref_rres = create_ref_rres()
     FOR i=0, N_ELEMENTS(dp_chrom)-1 DO BEGIN ; overwrite eval_flag
-      tmp_chrom=(dp_chrom[i])
-      n_chrom=N_ELEMENTS(dp_chrom[i])
-      n_subst=N_ELEMENTS(tmp_chrom[i].subst.name)
+      tmp_chrom = (dp_chrom[i])
+      n_chrom = N_ELEMENTS(dp_chrom[i])
+      n_subst = N_ELEMENTS(tmp_chrom[i].subst.name)
       FOR j=0, n_chrom-1 DO BEGIN
         FOR k=0, n_subst-1 DO tmp_chrom[j].subst[k].rres=ref_rres
       ENDFOR
-      (dp_chrom[i])=tmp_chrom
+      (dp_chrom[i]) = tmp_chrom
     ENDFOR
   ENDIF
 

--- a/Load_Data/dp_correct_time.pro
+++ b/Load_Data/dp_correct_time.pro
@@ -4,8 +4,8 @@
 ;
 ; 2017 04 - added keyword FORCE_MONO_INC to enforce a monotonically increasing, equidistant timestamp
 ;           based on the median of all found timestamps.
-;           
-; 2020 06 - revised and simplified.          
+;
+; 2020 06 - revised and simplified.
 ;
 FUNCTION dp_correct_time, dp_chrom, FORCE_MONO_INC=force_mono_inc, VERBOSE=verbose, LOUD=loud
 
@@ -27,7 +27,7 @@ FUNCTION dp_correct_time, dp_chrom, FORCE_MONO_INC=force_mono_inc, VERBOSE=verbo
             w = WHERE(exp_jdate[1:-1]-exp_jdate[0:-2] LT 0., n_jumps)
 
             ; if a jump was found, trigger re-calculation of the timestamps
-            IF n_jumps GT 0 THEN force_mono_inc = 1 
+            IF n_jumps GT 0 THEN force_mono_inc = 1
 
             IF force_mono_inc THEN BEGIN
                 IF loud THEN $

--- a/Load_Data/dp_read_expinfofile.pro
+++ b/Load_Data/dp_read_expinfofile.pro
@@ -56,11 +56,11 @@ FUNCTION dp_read_expinfofile, file, exp_no, SEP=sep, DEF_OFFSET=def_offset, NAME
     ENDIF
 
 
-    ref_expinfo=create_ref_expinfo() ; generate the empty structure for experiment info
+    ref_expinfo = create_ref_expinfo() ; generate the empty structure for experiment info
     import=REPLICATE(ref_expinfo, nl-(def_offset+1))
 
     OPENR, lun, file, /GET_LUN ; reopen file for second run to import data
-      line=''
+      line = ''
         FOR i=0, def_offset-1 DO READF, lun, line ; skip file header this time
 
     READF, lun, line ; read col header
@@ -73,18 +73,18 @@ FUNCTION dp_read_expinfofile, file, exp_no, SEP=sep, DEF_OFFSET=def_offset, NAME
       import_tags=strreplace_iter(import_tags, remove_strings[i], '_', n_iter=MAX(STRLEN(import_tags)))
     ENDFOR
 
-    col_ix=LONARR(N_ELEMENTS(search_tags))-1 ; get indices of respective columns...
+    col_ix = LONARR(N_ELEMENTS(search_tags))-1 ; get indices of respective columns...
     FOR i=0, N_ELEMENTS(search_tags)-1 DO BEGIN
       ix_vd=WHERE(STRMATCH(import_tags, search_tags[i], /FOLD_CASE) EQ 1)
-      IF ix_vd[0] EQ -1 THEN col_ix[i]=-1 ELSE col_ix[i]=ix_vd[0]
+      IF ix_vd[0] EQ -1 THEN col_ix[i] = -1 ELSE col_ix[i]=ix_vd[0]
     ENDFOR
 
     w_ess=[3, 5, 10, 12, 13, 16] ; fname, sample_name, sample_id, p0, p1, mfc_vol
-    found_ess_ix=col_ix[w_ess]
+    found_ess_ix = col_ix[w_ess]
 
     IF found_ess_ix[-1] EQ -1 AND (found_ess_ix[-3]*found_ess_ix[-2]) GT 0 THEN BEGIN
-      found_ess_ix[-1]=999
-      s_vol_select=0 ; coerce dp as s_vol because no MFC value found
+      found_ess_ix[-1] = 999
+      s_vol_select = 0 ; coerce dp as s_vol because no MFC value found
     ENDIF
 
     IF (found_ess_ix[-1] NE -1) AND (found_ess_ix[-3] EQ -1) AND (found_ess_ix[-2] EQ -1) THEN BEGIN
@@ -94,9 +94,9 @@ FUNCTION dp_read_expinfofile, file, exp_no, SEP=sep, DEF_OFFSET=def_offset, NAME
     ENDIF
 
     IF (WHERE(found_ess_ix EQ -1))[0] NE -1 THEN BEGIN
-      errormsg=STRARR(N_ELEMENTS(w_ess)+1)
-      errormsg[0]='Essential tag not found. Please make sure that the following parameters are specified:'
-      errormsg[1:-1]=search_tags[w_ess]
+      errormsg = STRARR(N_ELEMENTS(w_ess)+1)
+      errormsg[0] = 'Essential tag not found. Please make sure that the following parameters are specified:'
+      errormsg[1:-1] = search_tags[w_ess]
       !NULL=DIALOG_MESSAGE(errormsg, /ERROR)
       CLOSE, lun
       FREE_LUN, lun
@@ -148,9 +148,9 @@ FUNCTION dp_read_expinfofile, file, exp_no, SEP=sep, DEF_OFFSET=def_offset, NAME
       IF col_ix[17] NE -1 THEN import[i].Ts_cldhd = tmp[col_ix[17]]
       IF col_ix[18] NE -1 THEN import[i].Te_cldhd = tmp[col_ix[18]]
 
-      IF col_ix[19] NE -1 THEN import[i].ts = time2jultime(TIME=tmp[col_ix[19]])
-      IF col_ix[20] NE -1 THEN import[i].te = time2jultime(TIME=tmp[col_ix[20]])
-      IF col_ix[21] NE -1 THEN import[i].dt = time2jultime(TIME=tmp[col_ix[21]]) $
+      IF col_ix[19] NE -1 THEN import[i].ts = time2jultime(TIME = tmp[col_ix[19]])
+      IF col_ix[20] NE -1 THEN import[i].te = time2jultime(TIME = tmp[col_ix[20]])
+      IF col_ix[21] NE -1 THEN import[i].dt = time2jultime(TIME = tmp[col_ix[21]]) $
         ELSE IF import[i].ts NE !VALUES.D_NAN AND import[i].te NE !VALUES.D_NAN THEN $
                   import[i].dt = import[i].te - import[i].ts
 

--- a/Load_Data/dp_read_expinfofile.pro
+++ b/Load_Data/dp_read_expinfofile.pro
@@ -76,7 +76,7 @@ FUNCTION dp_read_expinfofile, file, exp_no, SEP=sep, DEF_OFFSET=def_offset, NAME
     col_ix = LONARR(N_ELEMENTS(search_tags))-1 ; get indices of respective columns...
     FOR i=0, N_ELEMENTS(search_tags)-1 DO BEGIN
       ix_vd=WHERE(STRMATCH(import_tags, search_tags[i], /FOLD_CASE) EQ 1)
-      IF ix_vd[0] EQ -1 THEN col_ix[i] = -1 ELSE col_ix[i]=ix_vd[0]
+      IF ix_vd[0] EQ -1 THEN col_ix[i] = -1 ELSE col_ix[i] = ix_vd[0]
     ENDFOR
 
     w_ess=[3, 5, 10, 12, 13, 16] ; fname, sample_name, sample_id, p0, p1, mfc_vol

--- a/Load_Data/dp_restore_chrom.pro
+++ b/Load_Data/dp_restore_chrom.pro
@@ -12,7 +12,7 @@
 FUNCTION dp_restore_chrom, dp_chrom, current_version, PATH=path_wd, FNAME=fname, VERBOSE=verbose
 
   dp_refr_status, MESSAGE='Restoring IAU_Chrom data...'
-  IF NOT KEYWORD_SET(verbose) THEN verbose=0
+  IF NOT KEYWORD_SET(verbose) THEN verbose = 0
   IF verbose THEN print, 'beginning to restore experiment(s)...'
 
   IF NOT KEYWORD_SET(fname) THEN $
@@ -29,7 +29,7 @@ FUNCTION dp_restore_chrom, dp_chrom, current_version, PATH=path_wd, FNAME=fname,
   exp_fname = STRARR(N_ELEMENTS(fname))
 
   FOR i=0, N_ELEMENTS(fname)-1 DO BEGIN             ; i-loop: number of selected chrom-files
-    exp_fname(i)=FILE_BASENAME(fname[i])
+    exp_fname(i) = FILE_BASENAME(fname[i])
 
     RESTORE, fname[i] ; gives structure "chrom"...
 
@@ -39,8 +39,8 @@ FUNCTION dp_restore_chrom, dp_chrom, current_version, PATH=path_wd, FNAME=fname,
       RETURN, dp_chrom
     ENDIF
 
-    m_chrom=!NULL ; empty temporary structures; "_m" = modified
-    new_chrom=!NULL
+    m_chrom = !NULL ; empty temporary structures; "_m" = modified
+    new_chrom = !NULL
                                                       ; modify the restored chrom structure...
     FOR j=0, N_ELEMENTS(chrom)-1 DO BEGIN           ; j-loop: elements of chrom, i.e. number of chromatograms
       instr_type=[instr_type, chrom[j].instr_type]
@@ -51,9 +51,9 @@ FUNCTION dp_restore_chrom, dp_chrom, current_version, PATH=path_wd, FNAME=fname,
       tmp0=STRCT_Redefine_Tag(m_chrom[j], TAG_NAME="exp_fname", TAG_DEF=exp_fname(i))
       tmp0=STRCT_Redefine_Tag(tmp0, TAG_NAME="iaudp_vers", TAG_DEF=FIX(current_version, TYPE=4))
 
-      new_subst=!NULL
+      new_subst = !NULL
 
-      ref_rres=create_ref_rres()
+      ref_rres = create_ref_rres()
 
         FOR k=0, N_ELEMENTS(m_chrom[j].subst)-1 DO BEGIN        ; k-loop elements of subst in each chrom
           tmp1=STRCT_Redefine_Tag(tmp0.subst[k], Tag_Name="rres", Tag_Def=ref_rres) ; tmp1: subst level [n_chrom, n_subst]
@@ -75,7 +75,7 @@ FUNCTION dp_restore_chrom, dp_chrom, current_version, PATH=path_wd, FNAME=fname,
 
   IF N_ELEMENTS(instr_type[uniq(instr_type)]) GT 1 THEN BEGIN
     msg=DIALOG_MESSAGE('Instrument types of experiments do not match. Aborted.', /ERROR)
-    chromlist=!NULL
+    chromlist = !NULL
   ENDIF
 
   dp_refr_status, MESSAGE='Data restored.'

--- a/Main/dp_destroy_wids.pro
+++ b/Main/dp_destroy_wids.pro
@@ -3,14 +3,14 @@
 ;
 ; AUTHOR: F. Obersteiner, Sep-2016. Modified Aug-2017 to use WIDGET_CONTROL -> bad_id
 ;
-; PURPOSE: closes widget(s) if identifier returns bad_id=0 (=not bad)
+; PURPOSE: closes widget(s) if identifier returns bad_id = 0 (=not bad)
 ;-
 ;------------------------------------------------------------------------------------------------------------------------
 PRO dp_destroy_wids, ALL=all, ID=id
 
   COMMON DP_WIDID
 
-  IF NOT KEYWORD_SET(ID) THEN ID=0
+  IF NOT KEYWORD_SET(ID) THEN ID = 0
 
   IF ID EQ -1 THEN RETURN
   IF NOT KEYWORD_SET(ALL) AND NOT KEYWORD_SET(ID) THEN RETURN

--- a/Main/dp_destroy_wids.pro
+++ b/Main/dp_destroy_wids.pro
@@ -3,7 +3,7 @@
 ;
 ; AUTHOR: F. Obersteiner, Sep-2016. Modified Aug-2017 to use WIDGET_CONTROL -> bad_id
 ;
-; PURPOSE: closes widget(s) if identifier returns bad_id = 0 (=not bad)
+; PURPOSE: closes widget(s) if identifier returns bad_id = 0 ( = not bad)
 ;-
 ;------------------------------------------------------------------------------------------------------------------------
 PRO dp_destroy_wids, ALL=all, ID=id

--- a/Main/dp_refr_status.pro
+++ b/Main/dp_refr_status.pro
@@ -1,7 +1,7 @@
 PRO dp_refr_status, MESSAGE=message, CLEAR=clear
 
   key1_set=KEYWORD_SET(message) ;+++ check if keywords set, return if neither is set
-  key2_set=KEYWORD_SET(clear)
+  key2_set = KEYWORD_SET(clear)
   IF key1_set+key2_set EQ 0 THEN RETURN
 
   COMMON DP_WIDID

--- a/Main/dp_strcts2current_version.pro
+++ b/Main/dp_strcts2current_version.pro
@@ -41,10 +41,10 @@ FUNCTION dp_gen_empty_rres, old_dp_chrom_strct, vcheck, current_version
   n_subst = N_ELEMENTS(old_dp_chrom_strct[0].subst)
 
   ; the sub-structure thats actually redefined empty...
-  ref_rres=create_ref_rres()
-  new_subst=!NULL
+  ref_rres = create_ref_rres()
+  new_subst = !NULL
 
-  tmp1=[]
+  tmp1 = []
 
   IF vcheck EQ -1 THEN BEGIN
     FOR i=0, n_chroms-1 DO BEGIN
@@ -57,7 +57,7 @@ FUNCTION dp_gen_empty_rres, old_dp_chrom_strct, vcheck, current_version
 
   FOR i=0, n_chroms-1 DO BEGIN ; for each chromatogram...
 
-    new_subst=[]
+    new_subst = []
 
     FOR j=0, n_subst-1 DO BEGIN ; for each species...
       tmp2=STRCT_Redefine_Tag(tmp1[i].subst[j], Tag_Name="rres", Tag_Def=ref_rres)

--- a/Main/dp_wid_main_ini.pro
+++ b/Main/dp_wid_main_ini.pro
@@ -64,12 +64,12 @@ PRO dp_wid_main_handle, event
     ;******************************************************************************************
     'load_expinfo' : $
       BEGIN
-        del_results=0
+        del_results = 0
         IF SIZE(dp_expcfg, /TYPE) EQ 11 THEN BEGIN ; dp_expcfg is already a LIST, i.e. data was loaded before
           quest=DIALOG_MESSAGE('Loaded ExpInfo found. Replace? Previous Results will be deleted...', $
                                 /QUESTION, /DEFAULT_NO, DIALOG_PARENT=dp_widid.dp_mainwid)
           IF quest EQ 'Yes' THEN BEGIN
-            del_results=1
+            del_results = 1
             dp_destroy_wids, ID=dp_widid.dp_dataproc
           ENDIF ELSE RETURN
         ENDIF
@@ -165,7 +165,7 @@ PRO dp_wid_main_handle, event
                spec_val=['Samples'];, 'Intercalibration', 'Non-Linearity Exp.', 'Precision Exp.']
              END
           1: BEGIN
-               spec_val='Samples'
+               spec_val = 'Samples'
              END
           ELSE:
         ENDCASE
@@ -177,7 +177,7 @@ PRO dp_wid_main_handle, event
     'expspec_dl' : $
       BEGIN
         IF N_ELEMENTS(dp_chrom) GT 1 THEN BEGIN
-          msg=DIALOG_MESSAGE('Selection prohibited; please load only one experiment.')
+          msg = DIALOG_MESSAGE('Selection prohibited; please load only one experiment.')
           ID_espec=WIDGET_INFO(event.top, find_by_uname='expspec_dl')
           WIDGET_CONTROL, ID_espec, SET_DROPLIST_SELECT=0
         ENDIF

--- a/Main/dp_wid_main_ini.pro
+++ b/Main/dp_wid_main_ini.pro
@@ -254,12 +254,15 @@ END
 
 PRO dp_wid_main_ini
 
-COMMON DP_DATA
-COMMON DP_WIDID
+  COMMON DP_DATA
+  COMMON DP_WIDID
+
+  title = 'IAU_DataProc_v' + dp_vers
+  cred = '(c) 2021 Univ. Frankfurt / IAU / Group A. Engel'
 
 ;++++++++++++ WIDGET BASE
-  mainbase=WIDGET_BASE(title='IAU_DP_v'+dp_vers, mbar=dp_mainmen, column=1,$
-                       XOFFSET= + 5, YOFFSET= + 5) ;rects[0, sel_mon] rects[1, sel_mon]
+  mainbase=WIDGET_BASE(TITLE=title, MBAR=dp_mainmen, COLUMN=1,$
+                       XOFFSET= + 5, YOFFSET= + 5)
 
 ;++++++++++++ MENUS
   fileID=WIDGET_BUTTON(dp_mainmen, VALUE='File', /MENU)
@@ -313,7 +316,7 @@ COMMON DP_WIDID
 ;++++++++++++ (c)
     dp_credits = WIDGET_BASE(dp_subbase1, uname='dp_credits', column=1)
       SEP = WIDGET_LABEL(dp_credits, VALUE='--', /ALIGN_LEFT)
-      TXT = WIDGET_LABEL(dp_credits, VALUE='(c) 2020 Univ. Frankfurt / IAU / Group A. Engel', /ALIGN_LEFT)
+      TXT = WIDGET_LABEL(dp_credits, VALUE=cred, /ALIGN_LEFT)
 
 ;++++++++++++ REALIZE!
   dp_widid.dp_mainwid = mainbase

--- a/Main/dp_wid_main_tools.pro
+++ b/Main/dp_wid_main_tools.pro
@@ -26,13 +26,13 @@ COMMON dp_data
     'restore_chrom' : $
       BEGIN
         IF SIZE(dp_chrom, /TYPE) EQ 11 THEN BEGIN
-          chromlist=[]
+          chromlist = []
           FOR i=0, N_ELEMENTS(dp_chrom)-1 DO BEGIN
             chromlist=[chromlist, ((dp_chrom[i]).exp_fname)[0]]
             IF i EQ 0 THEN substlist=LIST(((dp_chrom[0]).subst.name)[*,0]) $
               ELSE substlist.add, ((dp_chrom[i]).subst.name)[*,0]
           ENDFOR
-        ENDIF ELSE chromlist=''
+        ENDIF ELSE chromlist = ''
 
         WIDGET_CONTROL, ID_chroms_dl, set_VALUE=chromlist
         WIDGET_CONTROL, ID_expinfo_dl, set_VALUE=''
@@ -45,7 +45,7 @@ COMMON dp_data
         ;     0:not defined, 1:QPMS or SFMS, 2:ALMSCO_TOFMS, 3:TW_TOFMS, 4:GhostECD, 5:AED, 6:GHGGC_FID or _ECD
 
         IF SIZE(dp_chrom, /TYPE) EQ 11 THEN BEGIN
-          instr_type=((dp_chrom[0]).instr_type)[0]
+          instr_type = ((dp_chrom[0]).instr_type)[0]
 
           CASE 1 OF
             (instr_type LE 1): $
@@ -63,7 +63,7 @@ COMMON dp_data
 
     'load_expinfo' : $
       BEGIN
-        expinflist=[]
+        expinflist = []
         IF SIZE(dp_expcfg, /TYPE) EQ 11 THEN $
           FOR i=0, N_ELEMENTS(dp_chrom)-1 DO expinflist=[expinflist, ((dp_expcfg[i]).expinfo.expinfo_fname)[0]]
 
@@ -77,16 +77,16 @@ COMMON dp_data
         espec=espec_vals[WIDGET_INFO(ID_espec, /DROPLIST_SELECT)]
         FOR n=0, N_ELEMENTS(dp_expcfg)-1 DO BEGIN
           ITS = {instrument: instr, type: etype, spec: espec}
-          tmp_strct=(dp_expcfg)[n]  ; move structure out of list
-          tmp_strct.setup=ITS
-          (dp_expcfg)[n]=TEMPORARY(tmp_strct)  ; put strct with loaded values back into list
+          tmp_strct = (dp_expcfg)[n]  ; move structure out of list
+          tmp_strct.setup = ITS
+          (dp_expcfg)[n] = TEMPORARY(tmp_strct)  ; put strct with loaded values back into list
         ENDFOR
       END
 
     'restore_dp' : $
       BEGIN
-        chromlist=[]
-        expinflist=[]
+        chromlist = []
+        expinflist = []
         FOR i=0, N_ELEMENTS(dp_chrom)-1 DO BEGIN
           chromlist=[chromlist, ((dp_chrom[i]).exp_fname)[0]]
           expinflist=[expinflist, ((dp_expcfg[i]).expinfo.expinfo_fname)[0]]
@@ -97,7 +97,7 @@ COMMON dp_data
 
         WIDGET_CONTROL, ID_expinfo_dl, set_VALUE=expinflist
 
-        setup=((dp_expcfg[0]).setup)
+        setup = ((dp_expcfg[0]).setup)
 
         WIDGET_CONTROL, ID_instr, GET_VALUE=instr_vals
         WIDGET_CONTROL, ID_instr, SET_DROPLIST_SELECT=(WHERE(instr_vals EQ setup.instrument))[0]
@@ -114,7 +114,7 @@ COMMON dp_data
       BEGIN
         WIDGET_CONTROL, ID_expinfo_dl, SET_DROPLIST_SELECT=sel_exp ; adjust selection of expinfo droplist
 
-        setup=((dp_expcfg[sel_exp]).setup)
+        setup = ((dp_expcfg[sel_exp]).setup)
 
         WIDGET_CONTROL, ID_instr, GET_VALUE=instr_vals
         WIDGET_CONTROL, ID_instr, SET_DROPLIST_SELECT=(WHERE(instr_vals EQ setup.instrument))[0]
@@ -130,7 +130,7 @@ COMMON dp_data
       BEGIN
         WIDGET_CONTROL, ID_chroms_dl, SET_DROPLIST_SELECT=sel_expinfo ; adjust selection of chroms droplist
 
-        setup=((dp_expcfg[sel_expinfo]).setup)
+        setup = ((dp_expcfg[sel_expinfo]).setup)
 
         WIDGET_CONTROL, ID_instr, GET_VALUE=instr_vals
         WIDGET_CONTROL, ID_instr, SET_DROPLIST_SELECT=(WHERE(instr_vals EQ setup.instrument))[0]
@@ -147,9 +147,9 @@ COMMON dp_data
         WIDGET_CONTROL, ID_instr, GET_VALUE=instr_val
         instr=instr_val[WIDGET_INFO(ID_instr, /DROPLIST_SELECT)]
         IF SIZE(dp_expcfg, /TYPE) EQ 11 THEN BEGIN ; dp_expcfg was created, write new selection to dp_expcfg
-          tmp_strct=(dp_expcfg)[sel_exp]
-          tmp_strct.setup.instrument=instr
-          (dp_expcfg)[sel_exp]=tmp_strct
+          tmp_strct = (dp_expcfg)[sel_exp]
+          tmp_strct.setup.instrument = instr
+          (dp_expcfg)[sel_exp] = tmp_strct
         ENDIF ELSE BEGIN
 ;          msg=DIALOG_MESSAGE('Please load Experiment Info File(s) first.', /ERROR)
 ;          WIDGET_CONTROL, ID_instr, SET_DROPLIST_SELECT=0
@@ -161,9 +161,9 @@ COMMON dp_data
         WIDGET_CONTROL, ID_etype, GET_VALUE=type_val
         type=type_val[WIDGET_INFO(ID_etype, /DROPLIST_SELECT)]
         IF SIZE(dp_expcfg, /TYPE) EQ 11 THEN BEGIN
-          tmp_strct=(dp_expcfg)[sel_exp]
-          tmp_strct.setup.type=type
-          (dp_expcfg)[sel_exp]=tmp_strct
+          tmp_strct = (dp_expcfg)[sel_exp]
+          tmp_strct.setup.type = type
+          (dp_expcfg)[sel_exp] = tmp_strct
         ENDIF ELSE BEGIN
 ;          msg=DIALOG_MESSAGE('Please load Experiment Info File(s) first.', /ERROR)
 ;          WIDGET_CONTROL, ID_etype, SET_DROPLIST_SELECT=0
@@ -175,9 +175,9 @@ COMMON dp_data
         WIDGET_CONTROL, ID_espec, GET_VALUE=spec_val
         spec=spec_val[WIDGET_INFO(ID_espec, /DROPLIST_SELECT)]
         IF SIZE(dp_expcfg, /TYPE) EQ 11 THEN BEGIN
-          tmp_strct=(dp_expcfg)[sel_exp]
-          tmp_strct.setup.spec=spec
-          (dp_expcfg)[sel_exp]=tmp_strct
+          tmp_strct = (dp_expcfg)[sel_exp]
+          tmp_strct.setup.spec = spec
+          (dp_expcfg)[sel_exp] = tmp_strct
         ENDIF ELSE BEGIN
 ;          msg=DIALOG_MESSAGE('Please load Experiment Info File(s) first.', /ERROR)
 ;          WIDGET_CONTROL, ID_espec, SET_DROPLIST_SELECT=0

--- a/Plot/dp_plot_mrs_prc.pro
+++ b/Plot/dp_plot_mrs_prc.pro
@@ -107,7 +107,7 @@ PRO dp_plot_mrs_prc, sel_exp, sel_subst, SHOW_PRC=show_prc, SHOW_CAL_PRC=show_ca
         !NULL=DIALOG_MESSAGE('Please load calibration MRs first.', /INFORMATION)
         rETUrN
       ENDIF ELSE BEGIN
-        prelim_MRs = dp_calc_mrs(subst_name, sel_subst, sel_exp, dp_chrom, dp_expcfg, eval_mode)
+        prelim_MRs = dp_calc_mrs(subst_name, sel_subst, sel_exp, dp_chrom, dp_expcfg)
         sel_MRs = prelim_MRs[w_sam_end]
         w_fin=WHERE(FINITE(sel_MRs) EQ 1, n_fin)
         IF n_fin GT 0 THEN BEGIN

--- a/Plot/dp_plot_mrs_prc.pro
+++ b/Plot/dp_plot_mrs_prc.pro
@@ -10,10 +10,10 @@ PRO dp_plot_mrs_prc, sel_exp, sel_subst, SHOW_PRC=show_prc, SHOW_CAL_PRC=show_ca
 
  COMMON dp_data
 
-  IF NOT KEYWORD_SET(show_prc) THEN show_prc=0
-  IF NOT KEYWORD_SET(show_cal_prc) THEN show_cal_prc=0
-  IF NOT KEYWORD_SET(show_mrs) THEN show_mrs=0
-  IF NOT KEYWORD_SET(eval_mode) THEN eval_mode=0 ; default: area
+  IF NOT KEYWORD_SET(show_prc) THEN show_prc = 0
+  IF NOT KEYWORD_SET(show_cal_prc) THEN show_cal_prc = 0
+  IF NOT KEYWORD_SET(show_mrs) THEN show_mrs = 0
+  IF NOT KEYWORD_SET(eval_mode) THEN eval_mode = 0 ; default: area
 
   IF KEYWORD_SET(show_prc) AND KEYWORD_SET(show_mrs) THEN RETURN
 
@@ -111,9 +111,9 @@ PRO dp_plot_mrs_prc, sel_exp, sel_subst, SHOW_PRC=show_prc, SHOW_CAL_PRC=show_ca
         sel_MRs = prelim_MRs[w_sam_end]
         w_fin=WHERE(FINITE(sel_MRs) EQ 1, n_fin)
         IF n_fin GT 0 THEN BEGIN
-          x=x[w_fin]
-          sel_MRs=sel_MRs[w_fin]
-          sam_names=sam_names[w_fin]
+          x = x[w_fin]
+          sel_MRs = sel_MRs[w_fin]
+          sam_names = sam_names[w_fin]
           yrange=[MIN(sel_MRs)-(MAX(sel_MRs)-MIN(sel_MRs))*0.05, MAX(sel_MRs)+(MAX(sel_MRs)-MIN(sel_MRs))*0.05]
 
           p_mr = plot($

--- a/Plot/dp_plot_mrs_prc.pro
+++ b/Plot/dp_plot_mrs_prc.pro
@@ -6,16 +6,16 @@
 ; PURPOSE: plot block precisions and mixing ratios for each sample.
 ;-
 ;------------------------------------------------------------------------------------------------------------------------
-PRO dp_plot_mrs_prc, sel_exp, sel_subst, SHOW_PRC=show_prc, SHOW_CAL_PRC=show_cal_prc, SHOW_MRS=show_mrs, $
-                     EVAL_MODE=eval_mode
+PRO dp_plot_mrs_prc, sel_exp, sel_subst, SHOW_PRC=show_prc, SHOW_CAL_PRC=show_cal_prc, SHOW_MRS=show_mrs, EVAL_MODE=eval_mode
 
  COMMON dp_data
 
   IF NOT KEYWORD_SET(show_prc) THEN show_prc=0
   IF NOT KEYWORD_SET(show_cal_prc) THEN show_cal_prc=0
   IF NOT KEYWORD_SET(show_mrs) THEN show_mrs=0
-  IF KEYWORD_SET(show_prc) AND KEYWORD_SET(show_mrs) THEN RETURN
   IF NOT KEYWORD_SET(eval_mode) THEN eval_mode=0 ; default: area
+
+  IF KEYWORD_SET(show_prc) AND KEYWORD_SET(show_mrs) THEN RETURN
 
   IF ((dp_expcfg[sel_exp]).cal_mrs.canister) NE '' THEN cal_mrs_ok = 1 ELSE cal_mrs_ok = 0
   IF ((dp_expcfg[sel_exp]).instr_prc.instrument) NE '' THEN ins_prc_ok = 1 ELSE ins_prc_ok = 0
@@ -27,7 +27,7 @@ PRO dp_plot_mrs_prc, sel_exp, sel_subst, SHOW_PRC=show_prc, SHOW_CAL_PRC=show_ca
   id_cal = (WHERE(STRUPCASE(sid_name) EQ 'CALIBRATION'))[0] +1 ; configure IDs
   id_sam = (WHERE(STRUPCASE(sid_name) EQ 'AIR'))[0] +1
   id_tgt = (WHERE(STRUPCASE(sid_name) EQ 'TARGET'))[0] +1
-  
+
   sam_treat = (dp_chrom[sel_exp])[0].subst[sel_subst].rres.sam_treat
   IF sam_treat EQ 'individual' THEN BEGIN
     w_sam_end = WHERE((dp_expcfg[sel_exp]).sequence.id EQ id_sam OR (dp_expcfg[sel_exp]).sequence.id EQ id_tgt , n_sam)
@@ -35,7 +35,7 @@ PRO dp_plot_mrs_prc, sel_exp, sel_subst, SHOW_PRC=show_prc, SHOW_CAL_PRC=show_ca
   ENDIF ELSE BEGIN
     sam_names = ((dp_expcfg[sel_exp]).expinfo.s_name)[w_sam_init]
   ENDELSE
-  
+
   IF n_sam LT 1 THEN RETURN
 
   FOR i=0, n_sam-1 DO sam_names[i] = STRING(9b) + sam_names[i] + STRING(9b)
@@ -48,7 +48,7 @@ PRO dp_plot_mrs_prc, sel_exp, sel_subst, SHOW_PRC=show_prc, SHOW_CAL_PRC=show_ca
 ;+++++++++
 ;+++++++++ Call precision plot
   IF show_prc THEN BEGIN
-    
+
       IF show_cal_prc THEN BEGIN
           CASE eval_mode OF
               0: prc = (((dp_chrom[sel_exp]).subst[sel_subst].rres.rsp_area.cal_block_rsd)[w_cal_end])*100D
@@ -67,15 +67,15 @@ PRO dp_plot_mrs_prc, sel_exp, sel_subst, SHOW_PRC=show_prc, SHOW_CAL_PRC=show_ca
           ENDCASE
           t_suffix = 'samples'
           c = 'b'
-      ENDELSE   
-  
+      ENDELSE
+
       w_fin = WHERE(FINITE(prc) EQ 1, n_fin)
       IF n_fin GT 0 THEN BEGIN
         x = x[w_fin]
         prc = prc[w_fin]
         sam_names = sam_names[w_fin]
         yrange = [MIN(prc)-(MAX(prc)-MIN(prc))*0.1, MAX(prc)+(MAX(prc)-MIN(prc))*0.1]
-  
+
         p_prc = plot($
                      x, prc, $
                      XRANGE=[0.5, n_sam+0.5], $
@@ -91,10 +91,10 @@ PRO dp_plot_mrs_prc, sel_exp, sel_subst, SHOW_PRC=show_prc, SHOW_CAL_PRC=show_ca
                      SYM_SIZE=3.0, $
                      SYM_COLOR=c $
                      )
-  
+
          dp_refr_status, MESSAGE='Created precision plot.'
        ENDIF ELSE !NULL=DIALOG_MESSAGE('No displayable results found.', /INFORMATION)
-     
+
   ENDIF
 
 
@@ -102,12 +102,12 @@ PRO dp_plot_mrs_prc, sel_exp, sel_subst, SHOW_PRC=show_prc, SHOW_CAL_PRC=show_ca
 ;+++++++++
 ;+++++++++ Call mixing ratio plot
   IF show_mrs THEN BEGIN
-    
+
       IF NOT cal_mrs_ok THEN BEGIN
         !NULL=DIALOG_MESSAGE('Please load calibration MRs first.', /INFORMATION)
         rETUrN
       ENDIF ELSE BEGIN
-        prelim_MRs = dp_calc_mrs(subst_name, sel_subst, sel_exp, dp_chrom, dp_expcfg)
+        prelim_MRs = dp_calc_mrs(subst_name, sel_subst, sel_exp, dp_chrom, dp_expcfg, eval_mode)
         sel_MRs = prelim_MRs[w_sam_end]
         w_fin=WHERE(FINITE(sel_MRs) EQ 1, n_fin)
         IF n_fin GT 0 THEN BEGIN
@@ -115,7 +115,7 @@ PRO dp_plot_mrs_prc, sel_exp, sel_subst, SHOW_PRC=show_prc, SHOW_CAL_PRC=show_ca
           sel_MRs=sel_MRs[w_fin]
           sam_names=sam_names[w_fin]
           yrange=[MIN(sel_MRs)-(MAX(sel_MRs)-MIN(sel_MRs))*0.05, MAX(sel_MRs)+(MAX(sel_MRs)-MIN(sel_MRs))*0.05]
-  
+
           p_mr = plot($
                       x, sel_MRs, $
                       XRANGE=[0.5, n_sam+0.5], $
@@ -134,7 +134,7 @@ PRO dp_plot_mrs_prc, sel_exp, sel_subst, SHOW_PRC=show_prc, SHOW_CAL_PRC=show_ca
           dp_refr_status, MESSAGE='Created mixing ratio plot.'
         ENDIF ELSE !NULL=DIALOG_MESSAGE('No displayable results found.', /INFORMATION)
       ENDELSE
-    
+
   ENDIF
 
 

--- a/Plot/dp_plot_rres_diag.pro
+++ b/Plot/dp_plot_rres_diag.pro
@@ -14,9 +14,9 @@ PRO dp_plot_rres_diag, sel_exp, sel_subst, DIAGNOSTIC=diagnostic, RRES=rres, SAV
 ; diagnostic = 0 (none), 1 (normalised ret. time, height/area and S/N), 2 (delta t enrich, enriched Volume)
 
 
-  IF NOT KEYWORD_SET(rres) THEN rres=0
-  IF NOT KEYWORD_SET(diagnostic) THEN diagnostic=0
-  IF NOT KEYWORD_SET(pic_filetype) THEN pic_filetype='.ps'
+  IF NOT KEYWORD_SET(rres) THEN rres = 0
+  IF NOT KEYWORD_SET(diagnostic) THEN diagnostic = 0
+  IF NOT KEYWORD_SET(pic_filetype) THEN pic_filetype = '.ps'
 
   COMMON dp_data
 
@@ -35,7 +35,7 @@ PRO dp_plot_rres_diag, sel_exp, sel_subst, DIAGNOSTIC=diagnostic, RRES=rres, SAV
   id_tgt = (WHERE(STRUPCASE(sid_name) EQ 'TARGET'))[0] +1
 
   vd_data= WHERE(i_flag GE 1 AND r_flag EQ 1)
-  vd_sam = WHERE(s_id EQ id_sam[0] AND i_flag GE 1 AND r_flag NE 0) ; r_flag=0 -> not evaluated
+  vd_sam = WHERE(s_id EQ id_sam[0] AND i_flag GE 1 AND r_flag NE 0) ; r_flag = 0 -> not evaluated
   vd_tgt = WHERE(s_id EQ id_tgt[0] AND i_flag GE 1 AND r_flag NE 0)
   vd_cal = WHERE(s_id EQ id_cal[0] AND i_flag GE 1 AND r_flag NE 0)
 
@@ -60,7 +60,7 @@ PRO dp_plot_rres_diag, sel_exp, sel_subst, DIAGNOSTIC=diagnostic, RRES=rres, SAV
   mp = REPLICATE(!VALUES.D_NAN, N_ELEMENTS(time))
   IF ((dp_expcfg[sel_exp]).instr_prc.instrument) NE '' AND *(dp_expcfg[sel_exp]).instr_prc.substance NE !NULL $
     THEN BEGIN
-      w=WHERE(*(dp_expcfg[sel_exp]).instr_prc.substance EQ name)
+      w = WHERE(*(dp_expcfg[sel_exp]).instr_prc.substance EQ name)
       IF w[0] NE -1 THEN $
         mp[*]=(*(dp_expcfg[sel_exp]).instr_prc.mp_rel)[w]
     ENDIF
@@ -80,41 +80,41 @@ PRO dp_plot_rres_diag, sel_exp, sel_subst, DIAGNOSTIC=diagnostic, RRES=rres, SAV
   IF rres THEN BEGIN
 
     IF vd_data[0] NE -1 THEN BEGIN
-      p = dp_modify_plot(p=p)
-      p.p1.title=title
-      skip_save=0
+      p = dp_modify_plot(p = p)
+      p.p1.title = title
+      skip_save = 0
     ENDIF ELSE BEGIN
 ;      msg=DIALOG_MESSAGE(exp_name+': Please run calculations first.', /INFORMATION)
-      skip_save=1
+      skip_save = 1
     ENDELSE
 
     ; Cal-Messungen, welche zur Auswertung verwendet werden
     IF vd_cal[0] NE -1 THEN BEGIN
-      x1=time[vd_cal]
+      x1 = time[vd_cal]
       y1=signal[vd_cal];/mean(signal[vd_cal], /nan)
       p = dp_modify_plot(p=p, x1=x1, y1=y1)
     ENDIF
 
     ; Sample - Messungen, welche ausgewertet werden
     IF vd_sam[0] NE -1 THEN BEGIN
-      x2=time[vd_sam]
+      x2 = time[vd_sam]
       y2=signal[vd_sam];/mean(signal[vd_cal],/nan)
-      yerr2=mp[vd_sam]
+      yerr2 = mp[vd_sam]
       p = dp_modify_plot(p=p, x2=x2, y2=y2, yerr2=yerr2)
     ENDIF
 
     ; Target-Messungen
     IF vd_tgt[0] NE -1 THEN BEGIN
-      x4=time[vd_tgt]
+      x4 = time[vd_tgt]
       y4=signal[vd_tgt];/mean(signal[vd_cal],/nan)
-      yerr4=mp[vd_tgt]
+      yerr4 = mp[vd_tgt]
       p = dp_modify_plot(p=p, x4=x4, y4=y4, yerr4=yerr4)
     ENDIF
 
     ; cal interpolation
     IF vd_data[0] NE -1 THEN BEGIN
-      x7=time[vd_data]
-      y7=cal_interpol
+      x7 = time[vd_data]
+      y7 = cal_interpol
       p = dp_modify_plot(p=p, x7=x7, y7=y7)
     ENDIF
 
@@ -132,27 +132,27 @@ PRO dp_plot_rres_diag, sel_exp, sel_subst, DIAGNOSTIC=diagnostic, RRES=rres, SAV
     IF SIZE(p2,/type) EQ 8 THEN p2.p1.refresh,/disable
 
     ; Retentionszeit plotten
-    x1=INDGEN(N_ELEMENTS(time))+1
-    y1=DBLARR(N_ELEMENTS(time))*!Values.D_NAN
+    x1 = INDGEN(N_ELEMENTS(time))+1
+    y1 = DBLARR(N_ELEMENTS(time))*!Values.D_NAN
     y1[vd_data] = (t_ret[vd_data]/mean(t_ret[vd_data],/NAN))
 
     p2=dp_modify_plot2_multi(p2=p2, x1=x1,y1=y1 )
-    p2.p1.title="Diagnostic plot for: " + title
+    p2.p1.title = "Diagnostic plot for: " + title
 
 
     ; Height vs. Area plotten
-    x2=x1
-    y2=DBLARR(N_ELEMENTS(time))*!Values.D_NAN
-    y2[vd_data]=(n_hv/n_av)[vd_data]
+    x2 = x1
+    y2 = DBLARR(N_ELEMENTS(time))*!Values.D_NAN
+    y2[vd_data] = (n_hv/n_av)[vd_data]
 
     p2.p2.select
     p2=dp_modify_plot2_multi(p2=p2,x2=x2,y2=y2)
 
 
     ; S/N plotten
-    x3=x1
-    y3=DBLARR(N_ELEMENTS(time))*!Values.D_NAN
-    y3[vd_data]=s_n[vd_data]
+    x3 = x1
+    y3 = DBLARR(N_ELEMENTS(time))*!Values.D_NAN
+    y3[vd_data] = s_n[vd_data]
 
     p2.p3.select
     p2=dp_modify_plot2_multi(p2=p2,x3=x3,y3=y3)
@@ -171,27 +171,27 @@ PRO dp_plot_rres_diag, sel_exp, sel_subst, DIAGNOSTIC=diagnostic, RRES=rres, SAV
 
 
     ; Retentionszeit plotten
-    x1=INDGEN(N_ELEMENTS(time))+1
-    y1=DBLARR(N_ELEMENTS(time))*!Values.D_NAN
+    x1 = INDGEN(N_ELEMENTS(time))+1
+    y1 = DBLARR(N_ELEMENTS(time))*!Values.D_NAN
     y1[vd_data] = delta_t[vd_data]
 
     p2=dp_modify_plot2_multi(p2=p2, x1=x1,y1=y1 )
-    p2.p1.title="Diagnostic info from: " + dp_expcfg[sel_exp].expinfo[0].expinfo_fname
+    p2.p1.title = "Diagnostic info from: " + dp_expcfg[sel_exp].expinfo[0].expinfo_fname
 
 
     ; delta t enrich plotten
-    x2=x1
-    y2=DBLARR(N_ELEMENTS(time))*!Values.D_NAN
-    y2[vd_data]=vol[vd_data]
+    x2 = x1
+    y2 = DBLARR(N_ELEMENTS(time))*!Values.D_NAN
+    y2[vd_data] = vol[vd_data]
 
     p2.p2.select
     p2=dp_modify_plot2_multi(p2=p2,x2=x2,y2=y2)
 
 
     ; enrich volume (p difference) plotten
-    x3=x1
-    y3=DBLARR(N_ELEMENTS(time))*!Values.D_NAN
-    y3[vd_data]=mfc_vol[vd_data]
+    x3 = x1
+    y3 = DBLARR(N_ELEMENTS(time))*!Values.D_NAN
+    y3[vd_data] = mfc_vol[vd_data]
 
     p2.p3.select
     p2=dp_modify_plot2_multi(p2=p2,x3=x3,y3=y3)

--- a/Plot/dp_plot_tools.pro
+++ b/Plot/dp_plot_tools.pro
@@ -265,7 +265,7 @@ FUNCTION dp_create_plotobj2_multi, ytitle1=ytitle1, ytitle2=ytitle2, ytitle3=yti
   dimensions=[(0.35*screensize[0]),0.6*screensize[1]]
   ticklen = 0.01
 
-  date = label_date(DATE_FORMAT='%H:%I')
+  date = label_date(DATE_FORMAT = '%H:%I')
   xtickformat = 'LABEL_DATE'
 
   tickfont_size = 14

--- a/Plot/dp_plot_tools.pro
+++ b/Plot/dp_plot_tools.pro
@@ -28,7 +28,7 @@ FUNCTION dp_create_plotobj
   dimensions = [0.6*screensize[0],0.6*screensize[1]]
   ticklen = 0.01
 
-  date = label_date(date_format='%H:%I')
+  date = label_date(date_format = '%H:%I')
   xtickformat = 'LABEL_DATE'
 
   tickfont_size = 14
@@ -67,64 +67,64 @@ FUNCTION dp_create_plotobj
   p2 = errorplot([!Values.D_NAN],[!Values.D_NAN],color='b', /OVERPLOT, THICK=1, LINESTYLE=0, name="Sample",$
                   errorbar_capsize=errorbar_capsize,$
                   errorbar_thick=errorbar_thick)
-  p2.symbol="circle"
-  p2.sym_size=2
-  p2.sym_filled=1
-  p2.sym_color='blue'
-  p2.linestyle=" "
+  p2.symbol = "circle"
+  p2.sym_size = 2
+  p2.sym_filled = 1
+  p2.sym_color = 'blue'
+  p2.linestyle = " "
 
 
   p3 = errorplot([!Values.D_NAN],[!Values.D_NAN],color='r', /OVERPLOT, THICK=1, LINESTYLE=0, name="Cal")
-  p3.symbol="circle"
-  p3.linestyle=" "
-  p3.sym_size=2
-  p3.sym_thick=2
-  p3.sym_filled=1
-  p3.sym_color='red'
+  p3.symbol = "circle"
+  p3.linestyle = " "
+  p3.sym_size = 2
+  p3.sym_thick = 2
+  p3.sym_filled = 1
+  p3.sym_color = 'red'
 
 
   p4 = errorplot([!Values.D_NAN],[!Values.D_NAN],color='purple', /OVERPLOT, THICK=1, LINESTYLE=0, name="Target",$
                   errorbar_capsize=errorbar_capsize,$
                   errorbar_thick=errorbar_thick)
-  p4.symbol="circle"
-  p4.linestyle=" "
-  p4.sym_size=2
-  p4.sym_thick=2
-  p4.sym_filled=1
-  p4.sym_color='purple'
+  p4.symbol = "circle"
+  p4.linestyle = " "
+  p4.sym_size = 2
+  p4.sym_thick = 2
+  p4.sym_filled = 1
+  p4.sym_color = 'purple'
 
 
   p5 = errorplot([!Values.D_NAN],[!Values.D_NAN],color='g', /OVERPLOT, THICK=1, LINESTYLE=0, name="Lin.Fit")
-  p5.symbol="circle"
-  p5.linestyle=2
-  p5.thick=thick
-  p5.sym_filled=filled
-  p5.color='orange'
+  p5.symbol = "circle"
+  p5.linestyle = 2
+  p5.thick = thick
+  p5.sym_filled = filled
+  p5.color = 'orange'
 
 
   p6 = errorplot([!Values.D_NAN],[!Values.D_NAN],color='b', /OVERPLOT, THICK=1, LINESTYLE=0, name="Run.Mean")
-  p6.symbol="circle"
-  p6.linestyle=2
-  p6.thick=thick
-  p6.sym_filled=filled
-  p6.color='blue'
+  p6.symbol = "circle"
+  p6.linestyle = 2
+  p6.thick = thick
+  p6.sym_filled = filled
+  p6.color = 'blue'
 
 
   p7 = errorplot([!Values.D_NAN],[!Values.D_NAN],color='c', /OVERPLOT, THICK=1, LINESTYLE=0, name="Cal.Interpolation")
-  p7.symbol="circle"
-  p7.linestyle=2
-  p7.thick=thick
-  p7.sym_filled=filled
-  p7.color='green'
+  p7.symbol = "circle"
+  p7.linestyle = 2
+  p7.thick = thick
+  p7.sym_filled = filled
+  p7.color = 'green'
 
 
   p8 = errorplot([!Values.D_NAN],[!Values.D_NAN],color='r', /OVERPLOT, THICK=1, LINESTYLE=0, name="Cal.Mean")
-  p8.symbol="circle"
-  p8.sym_size=1
-  p8.sym_filled=filled
-  p8.linestyle=2
-  p8.thick=thick
-  p8.color='magenta'
+  p8.symbol = "circle"
+  p8.sym_size = 1
+  p8.sym_filled = filled
+  p8.linestyle = 2
+  p8.thick = thick
+  p8.color = 'magenta'
 
 
 
@@ -137,9 +137,9 @@ FUNCTION dp_create_plotobj
 
   y_rgt = axis('Y',tickdir=1, textpos=1, location=[1,0], ticklen=ticklen )
 
-  y_rgt.tickfont_size=14
-  y_rgt.text_color='blue'
-  y_rgt.title='Normalised Detector Response (Sample Gas)'
+  y_rgt.tickfont_size = 14
+  y_rgt.text_color = 'blue'
+  y_rgt.title = 'Normalised Detector Response (Sample Gas)'
 
   pltstrct = {p1:p1,p2:p2,p3:p3,p4:p4,p5:p5,p6:p6,p7:p7,p8:p8, $
               x_low:x_low, x_hgh:x_hgh, y_lft:y_lft,y_rgt:y_rgt, $
@@ -208,10 +208,10 @@ FUNCTION dp_modify_plot, p=p, x1=x1, y1=y1, yerr1=yerr1, x2=x2, y2=y2, yerr2=yer
   p.p3.getdata,x3,y3,yerr3
   p.p4.getdata,x4,y4,yerr4
 
-  IF x1[0] EQ 0. THEN x1=!VALUES.D_NAN
-  IF x2[0] EQ 0. THEN x2=!VALUES.D_NAN
-  IF x3[0] EQ 0. THEN x3=!VALUES.D_NAN
-  IF x4[0] EQ 0. THEN x4=!VALUES.D_NAN
+  IF x1[0] EQ 0. THEN x1 = !VALUES.D_NAN
+  IF x2[0] EQ 0. THEN x2 = !VALUES.D_NAN
+  IF x3[0] EQ 0. THEN x3 = !VALUES.D_NAN
+  IF x4[0] EQ 0. THEN x4 = !VALUES.D_NAN
 
   min_x=min([min(x1),min(x2),min(x3),min(x4)],/NaN)
   max_x=max([max(x1),max(x2),max(x3),max(x4)],/NaN)
@@ -226,7 +226,7 @@ FUNCTION dp_modify_plot, p=p, x1=x1, y1=y1, yerr1=yerr1, x2=x2, y2=y2, yerr2=yer
     p.p1.yrange=[0.,1.]
   ENDELSE
 
-  tmp=p.leg
+  tmp = p.leg
   tmp.delete
   p.leg = legend(TARGET=[p.p1,p.p2,p.p3,p.p4,p.p5,p.p6,p.p7,p.p8], /NORMAL, /AUTO_TEXT_COLOR, POSITION=[0.9825,0.95], $
                  SAMPLE_WIDTH=0.0005, SHADOW=0, HORIZONTAL_Spacing=0.05, VERTICAL_SPACING=0.02)
@@ -255,22 +255,22 @@ FUNCTION dp_create_plotobj2_multi, ytitle1=ytitle1, ytitle2=ytitle2, ytitle3=yti
 
   Device,  Get_Screen_Size=screenSize
 
-  XCenter=FIX(ScreenSize[0])
-  YCenter=FIX(ScreenSize[1])
+  XCenter = FIX(ScreenSize[0])
+  YCenter = FIX(ScreenSize[1])
   XOff = 0.8*screenSize[0]
   YOff = 0.6*screenSize[1]
-  xsize=0.25*screensize[0]
+  xsize = 0.25*screensize[0]
   position=[0.1,0.1,0.8,0.5]
   margin=[0.125,0.1,0.125,0.1]
   dimensions=[(0.35*screensize[0]),0.6*screensize[1]]
-  ticklen=0.01
+  ticklen = 0.01
 
-  date=label_date(DATE_FORMAT='%H:%I')
-  xtickformat='LABEL_DATE'
+  date = label_date(DATE_FORMAT='%H:%I')
+  xtickformat = 'LABEL_DATE'
 
-  tickfont_size=14
-  thick=1
-  filled=1
+  tickfont_size = 14
+  thick = 1
+  filled = 1
 
   p1 = errorplot([!Values.D_NAN],[!Values.D_NAN],$
                   margin=[0.15,0,0.05,0.1], $

--- a/Ref_Strcts/create_ref_calmrs.pro
+++ b/Ref_Strcts/create_ref_calmrs.pro
@@ -4,7 +4,7 @@ FUNCTION create_ref_calmrs
 ; how many elements the structure will contain. Also, array sizes might be
 ; different for different experiments loaded in the dp_data list.
 
-  ref_calmrs={ $
+  ref_calmrs = { $
               canister:  '', $
               substance:  PTR_NEW(/ALLOCATE_HEAP), $
               mr_ppt:     PTR_NEW(/ALLOCATE_HEAP), $  ; mixing ratio, absolut

--- a/Ref_Strcts/create_ref_cocorr.pro
+++ b/Ref_Strcts/create_ref_cocorr.pro
@@ -1,6 +1,6 @@
 FUNCTION create_ref_cocorr
 
-  ref_cocorr={ $
+  ref_cocorr = { $
               substance:  PTR_NEW(/ALLOCATE_HEAP), $
               comment:    STRARR(6), $
               cal_to_sam: PTR_NEW(/ALLOCATE_HEAP), $ ; [up, down]

--- a/Ref_Strcts/create_ref_expinfo.pro
+++ b/Ref_Strcts/create_ref_expinfo.pro
@@ -1,6 +1,6 @@
 FUNCTION  create_ref_expinfo
 
-  ref_expinfo=$
+  ref_expinfo = $
     { $
     expinfo_fname:  "" ,$               ; Dateinamen des Expinfo-Files
     opr:            "" ,$               ; Operator-Name

--- a/Ref_Strcts/create_ref_instrprc.pro
+++ b/Ref_Strcts/create_ref_instrprc.pro
@@ -1,6 +1,6 @@
 FUNCTION create_ref_instrprc
 
-  ref_instrprc={ $
+  ref_instrprc = { $
                 instrument: '', $
                 substance:  PTR_NEW(/ALLOCATE_HEAP), $
                 mp_ppt:     PTR_NEW(/ALLOCATE_HEAP), $ ; instrument 'repro' from precision experiments, absolute

--- a/Ref_Strcts/create_ref_tgtmrs.pro
+++ b/Ref_Strcts/create_ref_tgtmrs.pro
@@ -1,6 +1,6 @@
 FUNCTION create_ref_tgtmrs
 
-  ref_tgtmrs={ $
+  ref_tgtmrs = { $
               tgt_name:   PTR_NEW(/ALLOCATE_HEAP), $
               substance:  PTR_NEW(/ALLOCATE_HEAP), $
               mr_ppt:     PTR_NEW(/ALLOCATE_HEAP), $  ; mixing ratio, absolut

--- a/Ref_Strcts/create_ref_treatcfg.pro
+++ b/Ref_Strcts/create_ref_treatcfg.pro
@@ -1,6 +1,6 @@
 FUNCTION create_ref_treatcfg
 
-  ref_treatcfg={ $
+  ref_treatcfg = { $
                 substance:  PTR_NEW(/ALLOCATE_HEAP), $
                 cal_treat:     PTR_NEW(/ALLOCATE_HEAP), $
                 sam_treat:    PTR_NEW(/ALLOCATE_HEAP), $

--- a/Report/dp_mean2txt.pro
+++ b/Report/dp_mean2txt.pro
@@ -13,7 +13,6 @@ PRO dp_mean2txt, sel_exp,  PATH=path
 
   COMMON DP_DATA
 
-
   tmp_data = (dp_chrom[sel_exp])
   n_chrom = N_ELEMENTS(tmp_data)
   sel_chrom = FLOOR(n_chrom/2.)
@@ -137,7 +136,7 @@ PRO dp_mean2txt, sel_exp,  PATH=path
 
     subst_name = (substlist[sel_exp])[i]
 
-    IF call_mr_calc THEN prelim_MRs=dp_calc_mrs(name, i, sel_exp, dp_chrom, dp_expcfg, eval_mode) $
+    IF call_mr_calc THEN prelim_MRs=dp_calc_mrs(name, i, sel_exp, dp_chrom, dp_expcfg) $
       ELSE prelim_MRs=MAKE_ARRAY(n_chrom, /DOUBLE, VALUE=!Values.D_NAN)
 
     IF n_tgt GT 0 THEN BEGIN

--- a/Report/dp_mean2txt.pro
+++ b/Report/dp_mean2txt.pro
@@ -42,7 +42,7 @@ PRO dp_mean2txt, sel_exp,  PATH=path
   ENDELSE
 
   datestr = jultime2timestring(SYSTIME(/JULIAN), /YMD_CLEAN)
-  
+
   instr = instr.replace('/', '_')
   fname = DIALOG_PICKFILE(PATH=path, /WRITE, FILE=instr+'_dp_subst_mean.txt')
   IF STRLEN(fname) EQ 0 THEN RETURN
@@ -90,14 +90,14 @@ PRO dp_mean2txt, sel_exp,  PATH=path
             FORMAT='(D25.6)'), /REMOVE_ALL)
           cal_devtofit = STRCOMPRESS(STRING((tmp_data[sel_chrom].subst[i].rres.rsp_area.cal_devtofit)[0], $
             FORMAT='(D25.6)'), /REMOVE_ALL)
-  
+
           cal_block_rsd = (dp_chrom[sel_exp].subst[i].rres.rsp_area.cal_block_rsd)
           w_finite = WHERE(FINITE(cal_block_rsd) EQ 1, n_finite)
           IF n_finite EQ 0 THEN cal_block_rsd='NaN' $
           ELSE cal_block_rsd = STRCOMPRESS(STRING(mean($
             ((dp_chrom[sel_exp]).subst[i].rres.rsp_area.cal_block_rsd), $
             /NAN, /DOUBLE), FORMAT='(D25.6)'), /REMOVE_ALL)
-  
+
           sam_blocks_rsd = ((dp_chrom[sel_exp]).subst[i].rres.rsp_area.block_rsd)
           w_finite = WHERE(FINITE(sam_blocks_rsd) EQ 1, n_finite)
           IF n_finite EQ 0 THEN sam_blocks_rsd='NaN' $
@@ -112,14 +112,14 @@ PRO dp_mean2txt, sel_exp,  PATH=path
             FORMAT='(D25.6)'), /REMOVE_ALL)
           cal_devtofit = STRCOMPRESS(STRING((tmp_data[sel_chrom].subst[i].rres.rsp_height.cal_devtofit)[0], $
             FORMAT='(D25.6)'), /REMOVE_ALL)
-  
+
           cal_block_rsd = (dp_chrom[sel_exp].subst[i].rres.rsp_height.cal_block_rsd)
           w_finite = WHERE(FINITE(cal_block_rsd) EQ 1, n_finite)
           IF n_finite EQ 0 THEN cal_block_rsd='NaN' $
           ELSE cal_block_rsd = STRCOMPRESS(STRING(mean($
             ((dp_chrom[sel_exp]).subst[i].rres.rsp_height.cal_block_rsd), $
             /NAN, /DOUBLE), FORMAT='(D25.6)'), /REMOVE_ALL)
-  
+
           sam_blocks_rsd = ((dp_chrom[sel_exp]).subst[i].rres.rsp_height.block_rsd)
           w_finite = WHERE(FINITE(sam_blocks_rsd) EQ 1, n_finite)
           IF n_finite EQ 0 THEN sam_blocks_rsd='NaN' $
@@ -137,7 +137,7 @@ PRO dp_mean2txt, sel_exp,  PATH=path
 
     subst_name=(substlist[sel_exp])[i]
 
-    IF call_mr_calc THEN prelim_MRs=dp_calc_mrs(name, i, sel_exp, dp_chrom, dp_expcfg) $
+    IF call_mr_calc THEN prelim_MRs=dp_calc_mrs(name, i, sel_exp, dp_chrom, dp_expcfg, eval_mode) $
       ELSE prelim_MRs=MAKE_ARRAY(n_chrom, /DOUBLE, VALUE=!Values.D_NAN)
 
     IF n_tgt GT 0 THEN BEGIN

--- a/Report/dp_mean2txt.pro
+++ b/Report/dp_mean2txt.pro
@@ -77,7 +77,7 @@ PRO dp_mean2txt, sel_exp,  PATH=path
     sam_treat = tmp_data[sel_chrom].subst[i].rres.sam_treat
 
     IF *(dp_expcfg[sel_exp]).instr_prc.mp_rel NE !NULL THEN BEGIN
-      w=WHERE(STRUPCASE(*(dp_expcfg[sel_exp]).instr_prc.substance) EQ STRUPCASE(name))
+      w = WHERE(STRUPCASE(*(dp_expcfg[sel_exp]).instr_prc.substance) EQ STRUPCASE(name))
       IF w[0] NE -1 THEN $
         cal_prc = STRCOMPRESS(STRING((*(dp_expcfg[sel_exp]).instr_prc.mp_rel)[w[0]], FORMAT='(D25.6)'), /REMOVE_ALL)
     ENDIF ELSE cal_prc= 'NaN'
@@ -93,14 +93,14 @@ PRO dp_mean2txt, sel_exp,  PATH=path
 
           cal_block_rsd = (dp_chrom[sel_exp].subst[i].rres.rsp_area.cal_block_rsd)
           w_finite = WHERE(FINITE(cal_block_rsd) EQ 1, n_finite)
-          IF n_finite EQ 0 THEN cal_block_rsd='NaN' $
+          IF n_finite EQ 0 THEN cal_block_rsd = 'NaN' $
           ELSE cal_block_rsd = STRCOMPRESS(STRING(mean($
             ((dp_chrom[sel_exp]).subst[i].rres.rsp_area.cal_block_rsd), $
             /NAN, /DOUBLE), FORMAT='(D25.6)'), /REMOVE_ALL)
 
           sam_blocks_rsd = ((dp_chrom[sel_exp]).subst[i].rres.rsp_area.block_rsd)
           w_finite = WHERE(FINITE(sam_blocks_rsd) EQ 1, n_finite)
-          IF n_finite EQ 0 THEN sam_blocks_rsd='NaN' $
+          IF n_finite EQ 0 THEN sam_blocks_rsd = 'NaN' $
           ELSE sam_blocks_rsd = STRCOMPRESS(STRING(mean($
             ((dp_chrom[sel_exp]).subst[i].rres.rsp_area.block_rsd), $
             /NAN, /DOUBLE), FORMAT='(D25.6)'), /REMOVE_ALL)
@@ -115,14 +115,14 @@ PRO dp_mean2txt, sel_exp,  PATH=path
 
           cal_block_rsd = (dp_chrom[sel_exp].subst[i].rres.rsp_height.cal_block_rsd)
           w_finite = WHERE(FINITE(cal_block_rsd) EQ 1, n_finite)
-          IF n_finite EQ 0 THEN cal_block_rsd='NaN' $
+          IF n_finite EQ 0 THEN cal_block_rsd = 'NaN' $
           ELSE cal_block_rsd = STRCOMPRESS(STRING(mean($
             ((dp_chrom[sel_exp]).subst[i].rres.rsp_height.cal_block_rsd), $
             /NAN, /DOUBLE), FORMAT='(D25.6)'), /REMOVE_ALL)
 
           sam_blocks_rsd = ((dp_chrom[sel_exp]).subst[i].rres.rsp_height.block_rsd)
           w_finite = WHERE(FINITE(sam_blocks_rsd) EQ 1, n_finite)
-          IF n_finite EQ 0 THEN sam_blocks_rsd='NaN' $
+          IF n_finite EQ 0 THEN sam_blocks_rsd = 'NaN' $
           ELSE sam_blocks_rsd = STRCOMPRESS(STRING(mean($
             ((dp_chrom[sel_exp]).subst[i].rres.rsp_height.block_rsd), $
             /NAN, /DOUBLE), FORMAT='(D25.6)'), /REMOVE_ALL)
@@ -132,10 +132,10 @@ PRO dp_mean2txt, sel_exp,  PATH=path
     n_sam_blocks = STRCOMPRESS(STRING(n_finite, FORMAT='(I3)'), /REMOVE_ALL)
 
 
-    IF ((dp_expcfg[sel_exp]).cal_mrs.canister) EQ '' THEN call_mr_calc=0 $
+    IF ((dp_expcfg[sel_exp]).cal_mrs.canister) EQ '' THEN call_mr_calc = 0 $
       ELSE call_mr_calc=1
 
-    subst_name=(substlist[sel_exp])[i]
+    subst_name = (substlist[sel_exp])[i]
 
     IF call_mr_calc THEN prelim_MRs=dp_calc_mrs(name, i, sel_exp, dp_chrom, dp_expcfg, eval_mode) $
       ELSE prelim_MRs=MAKE_ARRAY(n_chrom, /DOUBLE, VALUE=!Values.D_NAN)

--- a/Report/dp_nlexp_res2txt.pro
+++ b/Report/dp_nlexp_res2txt.pro
@@ -23,17 +23,17 @@ PRO dp_nlexp_res2txt, nl_strct, sel_exp, sel_subst, DIR=dir
   tgts = nl_strct[0].tgt_names
   eval_mode = ((dp_chrom[sel_exp]).subst[sel_subst].rres.rsp_select)[0]
   mode_string = (['area', 'height'])[eval_mode]
-  
+
   ; FO 2020-03-01: use cal name from MR table if loaded
   IF ((dp_expcfg[sel_exp]).cal_mrs.canister) EQ '' THEN $
       cal = ((dp_expcfg[sel_exp]).expinfo.s_name)[(WHERE((dp_expcfg[sel_exp]).expinfo.s_id EQ id_cal))[0]] $
   ELSE $
       cal = ((dp_expcfg[sel_exp]).cal_mrs.canister)
-      
+
   ; FO 2020-03-02: included scale info
   w = WHERE(*((dp_expcfg[sel_exp]).tgt_mrs.SUBSTANCE) EQ subst)
   scale = (*((dp_expcfg[sel_exp]).tgt_mrs.SCALE))[w[-1]]
-    
+
   mass = STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_subst].mass[(dp_chrom[sel_exp]).subst[sel_subst].quant])[0], $
                           FORMAT='(D25.3)'), /REMOVE_ALL)
   fct_dgr_str = STRCOMPRESS(STRING(nl_strct.fct_dgr, FORMAT='(I)'), /REMOVE_ALL)
@@ -66,7 +66,7 @@ PRO dp_nlexp_res2txt, nl_strct, sel_exp, sel_subst, DIR=dir
 
   OPENW, lun, fname, /GET_LUN
   PRINTF, lun, '*** IAU_DP_v'+dp_vers+' NL REPORT ***', FORMAT='(A)'
-  
+
   ; FO 2020-03-01 add chrom date:
   PRINTF, lun, 'Experiment/Date:', sep, FILE_BASENAME((dp_chrom[sel_exp])[0].exp_fname[0]), sep, $
                jultime2timestring(mean(dp_chrom[sel_exp].jdate)), FORMAT='(A,A,A,A,A)'

--- a/Report/dp_prcexp_res2txt.pro
+++ b/Report/dp_prcexp_res2txt.pro
@@ -88,17 +88,17 @@ PRO dp_prcexp_res2txt, prc_res, sel_exp, DIR=dir
       res_arr = DBLARR(MAX(n_iter)*3+1, N_ELEMENTS(blszs))
       res_arr[0,*] = blszs
 
-      k=1
+      k = 1
       FOR j=0, MAX(n_iter)-1 DO BEGIN
         res_arr[k,*] = mean_rrsp[j, *]
         res_arr[k+1,*] = intra_prc[j,*]
         res_arr[k+2,*] = inter_prc[j, *]
-        k=k+3
+        k = k+3
       ENDFOR
 
       ; write data
       FOR l=0,N_ELEMENTS(blszs)-1 DO BEGIN
-        str=[]
+        str = []
         FOR m=0, MAX(n_iter)*3 DO BEGIN
           v_str = (STRCOMPRESS(STRING(res_arr[m,l], FORMAT='(D25.7)'), /REMoVE_ALL)).replace('-NaN', 'NaN')
           str = [str, v_str, sep]

--- a/Report/dp_report_list.pro
+++ b/Report/dp_report_list.pro
@@ -31,7 +31,7 @@ PRO dp_report_list, sel_exp, PATH=path, VERBOSE=verbose
     IF verbose THEN print, 'writing:', exp_list
 
     fname = DIALOG_PICKFILE(PATH=path, /WRITE, FILE=instr+'_dp_list_mxr.txt')
-    sep=STRING(9B)
+    sep = STRING(9B)
 
     exp_header = STRARR(3*N_ELEMENTS(exp_list))
 
@@ -43,9 +43,9 @@ PRO dp_report_list, sel_exp, PATH=path, VERBOSE=verbose
 
     colheader=make_array(n_elements(exp_header)+3, /STRING)
 
-    colheader[0]='sample_date'
-    colheader[1]='meas_date'
-    colheader[2]='sample_name'
+    colheader[0] = 'sample_date'
+    colheader[1] = 'meas_date'
+    colheader[2] = 'sample_name'
 
     FOR i=0, N_ELEMENTS(exp_header)-1 DO BEGIN
       colheader[i+3] = exp_header[i]
@@ -55,11 +55,11 @@ PRO dp_report_list, sel_exp, PATH=path, VERBOSE=verbose
     exp_ts = jultime2timestring(((dp_chrom[sel_exp]).subst.rres.dp_timestamp)[0])
 
     id_cal = (WHERE(STRUPCASE(sid_name) EQ 'CALIBRATION'))[0] +1 ; configure IDs
-    cal=((dp_expcfg[sel_exp]).expinfo.s_name)[(WHERE((dp_expcfg[sel_exp]).expinfo.s_id EQ id_cal))[0]]
+    cal = ((dp_expcfg[sel_exp]).expinfo.s_name)[(WHERE((dp_expcfg[sel_exp]).expinfo.s_id EQ id_cal))[0]]
 
     id_sam = (WHERE(STRUPCASE(sid_name) EQ 'AIR'))[0] +1 ; configure IDs
     id_tgt = (WHERE(STRUPCASE(sid_name) EQ 'TARGET'))[0] +1 ; configure IDs
-    sam_tgt=((dp_expcfg[sel_exp]).expinfo.s_name)[WHERE((dp_expcfg[sel_exp]).expinfo.s_id EQ id_sam  OR (dp_expcfg[sel_exp]).expinfo.s_id EQ id_tgt)]
+    sam_tgt = ((dp_expcfg[sel_exp]).expinfo.s_name)[WHERE((dp_expcfg[sel_exp]).expinfo.s_id EQ id_sam  OR (dp_expcfg[sel_exp]).expinfo.s_id EQ id_tgt)]
 
     samples = uniq(sam_tgt)
     nofsamples = n_elements(samples)
@@ -86,13 +86,13 @@ PRO dp_report_list, sel_exp, PATH=path, VERBOSE=verbose
 
 
     FOR i=0, N_ELEMENTS(exp_list)-1 DO BEGIN
-         name=exp_list[i]
+         name = exp_list[i]
 
  ; !
  ; missing check if .instr_prc structure pointer is defined and valid ("filled").
  ; !
-         w=WHERE(STRUPCASE(*(dp_expcfg[sel_exp]).instr_prc.substance) EQ STRUPCASE(name))
-         w2=WHERE(STRUPCASE(dp_chrom[sel_exp].subst.name) EQ STRUPCASE(name))
+         w = WHERE(STRUPCASE(*(dp_expcfg[sel_exp]).instr_prc.substance) EQ STRUPCASE(name))
+         w2 = WHERE(STRUPCASE(dp_chrom[sel_exp].subst.name) EQ STRUPCASE(name))
 
         IF w[0] NE -1 THEN BEGIN
           cal_prc = STRCOMPRESS(STRING((*(dp_expcfg[sel_exp]).instr_prc.mp_rel)[w[0]], FORMAT='(D25.6)'), /REMOVE_ALL)
@@ -135,15 +135,15 @@ PRO dp_report_list, sel_exp, PATH=path, VERBOSE=verbose
       printf, lun, 'YYYYDDMM', sep, m_date, FORMAT='(A,A,A,$)'
       printf, lun, sep, sample_name , FORMAT='(A,A,$)'
 
-      w=WHERE((dp_expcfg[sel_exp]).expinfo.s_name EQ sample_name)
-      w=w[(n_elements(w)-1)]
+      w = WHERE((dp_expcfg[sel_exp]).expinfo.s_name EQ sample_name)
+      w = w[(n_elements(w)-1)]
 
       FOR j=0, N_ELEMENTS(exp_list)-1 DO BEGIN;write  mixing ratio, rsd and prc flag
-        name=exp_list[j]
-        w2=WHERE(STRUPCASE(dp_chrom[sel_exp].subst.name) EQ STRUPCASE(name))
+        name = exp_list[j]
+        w2 = WHERE(STRUPCASE(dp_chrom[sel_exp].subst.name) EQ STRUPCASE(name))
 
-        w3=WHERE(*(dp_expcfg[sel_exp]).cal_mrs.substance EQ name)
-        w4=WHERE(STRUPCASE(*(dp_expcfg[sel_exp]).instr_prc.substance) EQ STRUPCASE(name))
+        w3 = WHERE(*(dp_expcfg[sel_exp]).cal_mrs.substance EQ name)
+        w4 = WHERE(STRUPCASE(*(dp_expcfg[sel_exp]).instr_prc.substance) EQ STRUPCASE(name))
 
         IF w2[0] NE -1 THEN BEGIN
           rsd_num= ((dp_chrom[sel_exp]).subst[w2[0]].rres.rsp_area.block_rsd)[w]
@@ -156,8 +156,8 @@ PRO dp_report_list, sel_exp, PATH=path, VERBOSE=verbose
             mxr_num =   ((dp_chrom[sel_exp]).subst[w2[0]].rres.rsp_area.block_rrsp)[w] * (*(dp_expcfg[sel_exp]).cal_mrs.mr_ppt)[w3[0]]
 
             IF(mxr_num LT 0) THEN BEGIN
-              delta='NaN'
-              mxr='NaN'
+              delta = 'NaN'
+              mxr = 'NaN'
             ENDIF ELSE BEGIN
 
               IF flag_num EQ 0 THEN  delta_num = mxr_num * cal_prc_num

--- a/Report/dp_report_list.pro
+++ b/Report/dp_report_list.pro
@@ -52,7 +52,7 @@ PRO dp_report_list, sel_exp, PATH=path, VERBOSE=verbose
     ENDFOR
 
 
-    exp_ts=jultime2timestring(((dp_chrom[sel_exp]).subst.rres.dp_timestamp)[0])
+    exp_ts = jultime2timestring(((dp_chrom[sel_exp]).subst.rres.dp_timestamp)[0])
 
     id_cal = (WHERE(STRUPCASE(sid_name) EQ 'CALIBRATION'))[0] +1 ; configure IDs
     cal=((dp_expcfg[sel_exp]).expinfo.s_name)[(WHERE((dp_expcfg[sel_exp]).expinfo.s_id EQ id_cal))[0]]
@@ -65,7 +65,7 @@ PRO dp_report_list, sel_exp, PATH=path, VERBOSE=verbose
     nofsamples = n_elements(samples)
 
 
-    m_date=jultime2timestring(((dp_chrom[sel_exp]).jdate)[0], /ONLYDATE)
+    m_date = jultime2timestring(((dp_chrom[sel_exp]).jdate)[0], /ONLYDATE)
 
     IF verbose THEN  print, (dp_expcfg[sel_exp]).cal_mrs.canister
 

--- a/Report/dp_res2txt.pro
+++ b/Report/dp_res2txt.pro
@@ -57,7 +57,7 @@ PRO dp_res2txt, sel_exp, sel_subst, PATH=path, DEF_PATH=def_path, ALL=all, BRIEF
 
   cal = ((dp_expcfg[sel_exp]).expinfo.s_name)[(WHERE((dp_expcfg[sel_exp]).expinfo.s_id EQ id_cal))[0]]
 
-  IF ((dp_expcfg[sel_exp]).cal_mrs.canister) EQ '' THEN call_mr_calc = 0 ELSE call_mr_calc=1
+  IF ((dp_expcfg[sel_exp]).cal_mrs.canister) EQ '' THEN call_mr_calc = 0 ELSE call_mr_calc = 1
 
   nvd = 1
   IF brief THEN sel_chroms = $
@@ -172,7 +172,7 @@ PRO dp_res2txt, sel_exp, sel_subst, PATH=path, DEF_PATH=def_path, ALL=all, BRIEF
 
 
         subst_name = (substlist[sel_exp])[sel_name]
-        IF call_mr_calc THEN prelim_MRs = dp_calc_mrs(subst_name, sel_name, sel_exp, dp_chrom, dp_expcfg, eval_mode) $
+        IF call_mr_calc THEN prelim_MRs = dp_calc_mrs(subst_name, sel_name, sel_exp, dp_chrom, dp_expcfg) $
           ELSE prelim_MRs = MAKE_ARRAY(n_chrom, /DOUBLE, VALUE=!Values.D_NAN)
 
         OPENW, lun, fname, /GET_LUN
@@ -343,7 +343,7 @@ PRO dp_res2txt, sel_exp, sel_subst, PATH=path, DEF_PATH=def_path, ALL=all, BRIEF
 
 
       subst_name = (substlist[sel_exp])[sel_name]
-      IF call_mr_calc THEN prelim_MRs = dp_calc_mrs(subst_name, sel_subst, sel_exp, dp_chrom, dp_expcfg, eval_mode) $
+      IF call_mr_calc THEN prelim_MRs = dp_calc_mrs(subst_name, sel_subst, sel_exp, dp_chrom, dp_expcfg) $
         ELSE prelim_MRs = MAKE_ARRAY(n_chrom, /DOUBLE, VALUE=!Values.D_NAN)
 
 

--- a/Report/dp_res2txt.pro
+++ b/Report/dp_res2txt.pro
@@ -113,7 +113,7 @@ PRO dp_res2txt, sel_exp, sel_subst, PATH=path, DEF_PATH=def_path, ALL=all, BRIEF
           unit = 'NA'
           cal_scale = 'NA'
         ENDELSE
-        
+
         cal_prc = 'NaN'
         IF *(dp_expcfg[sel_exp]).instr_prc.mp_rel NE !NULL THEN BEGIN
           w = WHERE(STRUPCASE(*(dp_expcfg[sel_exp]).instr_prc.substance) EQ STRUPCASE(name))
@@ -172,13 +172,13 @@ PRO dp_res2txt, sel_exp, sel_subst, PATH=path, DEF_PATH=def_path, ALL=all, BRIEF
 
 
         subst_name=(substlist[sel_exp])[sel_name]
-        IF call_mr_calc THEN prelim_MRs = dp_calc_mrs(subst_name, sel_name, sel_exp, dp_chrom, dp_expcfg, EVAL_MODE=eval_mode) $
+        IF call_mr_calc THEN prelim_MRs = dp_calc_mrs(subst_name, sel_name, sel_exp, dp_chrom, dp_expcfg, eval_mode) $
           ELSE prelim_MRs = MAKE_ARRAY(n_chrom, /DOUBLE, VALUE=!Values.D_NAN)
 
         OPENW, lun, fname, /GET_LUN
 
           PRINTF, lun, '*** IAU_DP_v'+dp_vers+' REPORT ***', FORMAT='(A)'
-          
+
           ; FO 2020-03-03 add chrom date:
           PRINTF, lun, 'Experiment/Date:', sep, FILE_BASENAME((dp_chrom[sel_exp])[0].exp_fname[0]), sep, $
                        jultime2timestring(mean(dp_chrom[sel_exp].jdate)), FORMAT='(A,A,A,A,A)'
@@ -284,7 +284,7 @@ PRO dp_res2txt, sel_exp, sel_subst, PATH=path, DEF_PATH=def_path, ALL=all, BRIEF
         unit = 'NA'
         cal_scale = 'NA'
       ENDELSE
-      
+
       cal_prc = 'NaN'
       IF *(dp_expcfg[sel_exp]).instr_prc.mp_rel NE !NULL THEN BEGIN
         w = WHERE(STRUPCASE(*(dp_expcfg[sel_exp]).instr_prc.substance) EQ STRUPCASE(name))
@@ -343,8 +343,8 @@ PRO dp_res2txt, sel_exp, sel_subst, PATH=path, DEF_PATH=def_path, ALL=all, BRIEF
 
 
       subst_name=(substlist[sel_exp])[sel_name]
-      IF call_mr_calc THEN prelim_MRs=dp_calc_mrs(subst_name, sel_subst, sel_exp, dp_chrom, dp_expcfg, EVAL_MODE=eval_mode) $
-        ELSE prelim_MRs=MAKE_ARRAY(n_chrom, /DOUBLE, VALUE=!Values.D_NAN)
+      IF call_mr_calc THEN prelim_MRs = dp_calc_mrs(subst_name, sel_subst, sel_exp, dp_chrom, dp_expcfg, eval_mode) $
+        ELSE prelim_MRs = MAKE_ARRAY(n_chrom, /DOUBLE, VALUE=!Values.D_NAN)
 
 
       OPENW, lun, fname, /GET_LUN

--- a/Report/dp_res2txt.pro
+++ b/Report/dp_res2txt.pro
@@ -20,11 +20,11 @@ PRO dp_res2txt, sel_exp, sel_subst, PATH=path, DEF_PATH=def_path, ALL=all, BRIEF
 
   COMMON DP_DATA
 
-  fname=''
-  fpath=''
-  prefix='nd_'
-  suffix='_iaudp'
-  sep=STRING(9B)
+  fname = ''
+  fpath = ''
+  prefix = 'nd_'
+  suffix = '_iaudp'
+  sep = STRING(9B)
   sel_eval_mode = ((dp_chrom[sel_exp]).subst[sel_subst].rres.rsp_select)[0]
 
   block_mode = ''
@@ -55,11 +55,11 @@ PRO dp_res2txt, sel_exp, sel_subst, PATH=path, DEF_PATH=def_path, ALL=all, BRIEF
   id_sam = (WHERE(STRUPCASE(sid_name) EQ 'AIR'))[0] +1
   id_tgt = (WHERE(STRUPCASE(sid_name) EQ 'TARGET'))[0] +1
 
-  cal=((dp_expcfg[sel_exp]).expinfo.s_name)[(WHERE((dp_expcfg[sel_exp]).expinfo.s_id EQ id_cal))[0]]
+  cal = ((dp_expcfg[sel_exp]).expinfo.s_name)[(WHERE((dp_expcfg[sel_exp]).expinfo.s_id EQ id_cal))[0]]
 
-  IF ((dp_expcfg[sel_exp]).cal_mrs.canister) EQ '' THEN call_mr_calc=0 ELSE call_mr_calc=1
+  IF ((dp_expcfg[sel_exp]).cal_mrs.canister) EQ '' THEN call_mr_calc = 0 ELSE call_mr_calc=1
 
-  nvd=1
+  nvd = 1
   IF brief THEN sel_chroms = $
     WHERE(((dp_expcfg[sel_exp]).expinfo.s_id) EQ id_sam OR ((dp_expcfg[sel_exp]).expinfo.s_id) EQ id_tgt, nvd) $
       ELSE sel_chroms = LINDGEN(n_chrom)
@@ -91,16 +91,16 @@ PRO dp_res2txt, sel_exp, sel_subst, PATH=path, DEF_PATH=def_path, ALL=all, BRIEF
         IF verbose THEN print, 'exporting results for: ', name
 
         fname=fpath+STRTRIM(prefix+name+(['_a', '_h'])[eval_mode]+block_mode+suffix+'.txt')
-        exp_ts=jultime2timestring(((dp_chrom[sel_exp]).subst[sel_name].rres.dp_timestamp)[0])
+        exp_ts = jultime2timestring(((dp_chrom[sel_exp]).subst[sel_name].rres.dp_timestamp)[0])
 
         IF instr NE 'GhOST_ECD' THEN $
           mass=STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].mass[(dp_chrom[sel_exp]).subst[sel_name].quant])[0], $
                            FORMAT='(D25.3)'), /REMOVE_ALL) ELSE mass='NaN'
 
         IF *(dp_expcfg[sel_exp]).cal_mrs.mr_ppt NE !NULL THEN BEGIN
-          cal_mr=!VALUES.D_NAN
+          cal_mr = !VALUES.D_NAN
           cal_scale= 'NA'
-          w=WHERE(STRUPCASE(*(dp_expcfg[sel_exp]).cal_mrs.substance) EQ STRUPCASE(name))
+          w = WHERE(STRUPCASE(*(dp_expcfg[sel_exp]).cal_mrs.substance) EQ STRUPCASE(name))
           IF w[0] NE -1 THEN BEGIN
             cal_mr = STRCOMPRESS(STRING((*(dp_expcfg[sel_exp]).cal_mrs.mr_ppt)[w[0]], FORMAT='(D25.6)'), /REMOVE_ALL)
             IF (*((dp_expcfg[sel_exp]).cal_mrs.unit)) NE !NULL THEN $
@@ -133,14 +133,14 @@ PRO dp_res2txt, sel_exp, sel_subst, PATH=path, DEF_PATH=def_path, ALL=all, BRIEF
                                  FORMAT='(D25.6)'), /REMOVE_ALL)
               cal_block_rsd = ((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_area.cal_block_rsd)
               w_finite = WHERE(FINITE(cal_block_rsd) EQ 1, n_finite)
-              IF n_finite EQ 0 THEN cal_block_rsd='NaN' $
+              IF n_finite EQ 0 THEN cal_block_rsd = 'NaN' $
                 ELSE cal_block_rsd = STRCOMPRESS(STRING(mean($
                                      ((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_area.cal_block_rsd), $
                                      /NAN, /DOUBLE), FORMAT='(D25.6)'), /REMOVE_ALL)
 
               sam_blocks_rsd = ((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_area.block_rsd)
               w_finite = WHERE(FINITE(sam_blocks_rsd) EQ 1, n_finite)
-              IF n_finite EQ 0 THEN sam_blocks_rsd='NaN' $
+              IF n_finite EQ 0 THEN sam_blocks_rsd = 'NaN' $
                 ELSE sam_blocks_rsd = STRCOMPRESS(STRING(mean($
                                      ((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_area.block_rsd), $
                                      /NAN, /DOUBLE), FORMAT='(D25.6)'), /REMOVE_ALL)
@@ -155,14 +155,14 @@ PRO dp_res2txt, sel_exp, sel_subst, PATH=path, DEF_PATH=def_path, ALL=all, BRIEF
                                  FORMAT='(D25.6)'), /REMOVE_ALL)
               cal_block_rsd = ((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_height.cal_block_rsd)
               w_finite = WHERE(FINITE(cal_block_rsd) EQ 1, n_finite)
-              IF n_finite EQ 0 THEN cal_block_rsd='NaN' $
+              IF n_finite EQ 0 THEN cal_block_rsd = 'NaN' $
                 ELSE cal_block_rsd = STRCOMPRESS(STRING(mean($
                                      ((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_height.cal_block_rsd), $
                                      /NAN, /DOUBLE), FORMAT='(D25.6)'), /REMOVE_ALL)
 
               sam_blocks_rsd = ((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_height.block_rsd)
               w_finite = WHERE(FINITE(sam_blocks_rsd) EQ 1, n_finite)
-              IF n_finite EQ 0 THEN sam_blocks_rsd='NaN' $
+              IF n_finite EQ 0 THEN sam_blocks_rsd = 'NaN' $
                 ELSE sam_blocks_rsd = STRCOMPRESS(STRING(mean($
                                      ((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_height.block_rsd), $
                                      /NAN, /DOUBLE), FORMAT='(D25.6)'), /REMOVE_ALL)
@@ -171,7 +171,7 @@ PRO dp_res2txt, sel_exp, sel_subst, PATH=path, DEF_PATH=def_path, ALL=all, BRIEF
 
 
 
-        subst_name=(substlist[sel_exp])[sel_name]
+        subst_name = (substlist[sel_exp])[sel_name]
         IF call_mr_calc THEN prelim_MRs = dp_calc_mrs(subst_name, sel_name, sel_exp, dp_chrom, dp_expcfg, eval_mode) $
           ELSE prelim_MRs = MAKE_ARRAY(n_chrom, /DOUBLE, VALUE=!Values.D_NAN)
 
@@ -207,30 +207,30 @@ PRO dp_res2txt, sel_exp, sel_subst, PATH=path, DEF_PATH=def_path, ALL=all, BRIEF
 
           FOR i=0, N_ELEMENTS(sel_chroms)-1 DO BEGIN
 
-              Chromatogram=FILE_BASENAME(((dp_chrom[sel_exp]).fname)[sel_chroms[i]])
+              Chromatogram = FILE_BASENAME(((dp_chrom[sel_exp]).fname)[sel_chroms[i]])
               Date=jultime2timestring(((dp_chrom[sel_exp]).jdate)[sel_chroms[i]], /ONLYDATE)
               Time=jultime2timestring(((dp_chrom[sel_exp]).jdate)[sel_chroms[i]], /HMSONLY)
-              Sample_Name=((dp_expcfg[sel_exp]).expinfo.s_name)[sel_chroms[i]]
+              Sample_Name = ((dp_expcfg[sel_exp]).expinfo.s_name)[sel_chroms[i]]
 
               CASE eval_mode OF
                 0: $
                   BEGIN
                     rR=STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_area.sam_rrsp)[sel_chroms[i]], FORMAT='(D25.6)'), /REMOVE_ALL)
-                    IF rR EQ '-NaN' THEN rR='NaN'
+                    IF rR EQ '-NaN' THEN rR = 'NaN'
                     Block_rR=STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_area.block_rrsp)[sel_chroms[i]], FORMAT='(D25.6)'), /REMOVE_ALL)
-                    IF Block_rR EQ '-NaN' THEN Block_rR='NaN'
+                    IF Block_rR EQ '-NaN' THEN Block_rR = 'NaN'
                     Block_RSD=STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_area.block_rsd)[sel_chroms[i]], FORMAT='(D25.6)'), /REMOVE_ALL)
-                    IF Block_RSD EQ '-NaN' THEN Block_RSD='NaN'
+                    IF Block_RSD EQ '-NaN' THEN Block_RSD = 'NaN'
                     prc_flag=STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_area.prc_flag)[sel_chroms[i]]), /REMOVE_ALL)
                   END
                 1: $
                   BEGIN
                     rR=STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_height.sam_rrsp)[sel_chroms[i]], FORMAT='(D25.6)'), /REMOVE_ALL)
-                    IF rR EQ '-NaN' THEN rR='NaN'
+                    IF rR EQ '-NaN' THEN rR = 'NaN'
                     Block_rR=STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_height.block_rrsp)[sel_chroms[i]], FORMAT='(D25.6)'), /REMOVE_ALL)
-                    IF Block_rR EQ '-NaN' THEN Block_rR='NaN'
+                    IF Block_rR EQ '-NaN' THEN Block_rR = 'NaN'
                     Block_RSD=STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_height.block_rsd)[sel_chroms[i]], FORMAT='(D25.6)'), /REMOVE_ALL)
-                    IF Block_RSD EQ '-NaN' THEN Block_RSD='NaN'
+                    IF Block_RSD EQ '-NaN' THEN Block_RSD = 'NaN'
                     prc_flag=STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_height.prc_flag)[sel_chroms[i]]), /REMOVE_ALL)
                   END
               ENDCASE
@@ -250,7 +250,7 @@ PRO dp_res2txt, sel_exp, sel_subst, PATH=path, DEF_PATH=def_path, ALL=all, BRIEF
 
 ;--------------------------------------------------*** single substance to individual txt file
   ENDIF ELSE BEGIN
-    sel_name=sel_subst
+    sel_name = sel_subst
 
       eval_mode = ((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_select)[0]
       mode_string = (['signal_area', 'signal_height'])[eval_mode]
@@ -261,17 +261,17 @@ PRO dp_res2txt, sel_exp, sel_subst, PATH=path, DEF_PATH=def_path, ALL=all, BRIEF
       name=STRCOMPRESS((dp_chrom[sel_exp])[ix].subst[sel_name].name, /REMOVE_ALL)
       IF verbose THEN print, 'exporting results for: ', name
 
-      exp_ts=jultime2timestring(((dp_chrom[sel_exp]).subst[sel_name].rres.dp_timestamp)[0])
+      exp_ts = jultime2timestring(((dp_chrom[sel_exp]).subst[sel_name].rres.dp_timestamp)[0])
 
       IF instr NE 'GhOST_ECD' THEN $
         mass=STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].mass[(dp_chrom[sel_exp]).subst[sel_name].quant])[0], $
                                 FORMAT='(D25.3)'), /REMOVE_ALL) ELSE mass='NaN'
 
       IF *(dp_expcfg[sel_exp]).cal_mrs.mr_ppt NE !NULL THEN BEGIN
-        cal_mr=!VALUES.D_NAN
+        cal_mr = !VALUES.D_NAN
         unit = 'NA'
         cal_scale= 'NA'
-        w=WHERE(STRUPCASE(*(dp_expcfg[sel_exp]).cal_mrs.substance) EQ STRUPCASE(name))
+        w = WHERE(STRUPCASE(*(dp_expcfg[sel_exp]).cal_mrs.substance) EQ STRUPCASE(name))
         IF w[0] NE -1 THEN BEGIN
           cal_mr = STRCOMPRESS(STRING((*(dp_expcfg[sel_exp]).cal_mrs.mr_ppt)[w[0]], FORMAT='(D25.6)'), /REMOVE_ALL)
           IF (*((dp_expcfg[sel_exp]).cal_mrs.unit)) NE !NULL THEN $
@@ -304,14 +304,14 @@ PRO dp_res2txt, sel_exp, sel_subst, PATH=path, DEF_PATH=def_path, ALL=all, BRIEF
                            FORMAT='(D25.6)'), /REMOVE_ALL)
             cal_block_rsd = ((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_area.cal_block_rsd)
             w_finite = WHERE(FINITE(cal_block_rsd) EQ 1, n_finite)
-            IF n_finite EQ 0 THEN cal_block_rsd='NaN' $
+            IF n_finite EQ 0 THEN cal_block_rsd = 'NaN' $
               ELSE cal_block_rsd = STRCOMPRESS(STRING(mean($
                                    ((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_area.cal_block_rsd), $
                                    /NAN, /DOUBLE), FORMAT='(D25.6)'), /REMOVE_ALL)
 
             sam_blocks_rsd = ((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_area.block_rsd)
             w_finite = WHERE(FINITE(sam_blocks_rsd) EQ 1, n_finite)
-            IF n_finite EQ 0 THEN sam_blocks_rsd='NaN' $
+            IF n_finite EQ 0 THEN sam_blocks_rsd = 'NaN' $
               ELSE sam_blocks_rsd = STRCOMPRESS(STRING(mean($
                                    ((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_area.block_rsd), $
                                    /NAN, /DOUBLE), FORMAT='(D25.6)'), /REMOVE_ALL)
@@ -327,14 +327,14 @@ PRO dp_res2txt, sel_exp, sel_subst, PATH=path, DEF_PATH=def_path, ALL=all, BRIEF
                            FORMAT='(D25.6)'), /REMOVE_ALL)
             cal_block_rsd = ((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_height.cal_block_rsd)
             w_finite = WHERE(FINITE(cal_block_rsd) EQ 1, n_finite)
-            IF n_finite EQ 0 THEN cal_block_rsd='NaN' $
+            IF n_finite EQ 0 THEN cal_block_rsd = 'NaN' $
               ELSE cal_block_rsd = STRCOMPRESS(STRING(mean($
                                    ((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_height.cal_block_rsd), $
                                    /NAN, /DOUBLE), FORMAT='(D25.6)'), /REMOVE_ALL)
 
             sam_blocks_rsd = ((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_height.block_rsd)
             w_finite = WHERE(FINITE(sam_blocks_rsd) EQ 1, n_finite)
-            IF n_finite EQ 0 THEN sam_blocks_rsd='NaN' $
+            IF n_finite EQ 0 THEN sam_blocks_rsd = 'NaN' $
               ELSE sam_blocks_rsd = STRCOMPRESS(STRING(mean($
                                    ((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_height.block_rsd), $
                                    /NAN, /DOUBLE), FORMAT='(D25.6)'), /REMOVE_ALL)
@@ -342,7 +342,7 @@ PRO dp_res2txt, sel_exp, sel_subst, PATH=path, DEF_PATH=def_path, ALL=all, BRIEF
       ENDCASE
 
 
-      subst_name=(substlist[sel_exp])[sel_name]
+      subst_name = (substlist[sel_exp])[sel_name]
       IF call_mr_calc THEN prelim_MRs = dp_calc_mrs(subst_name, sel_subst, sel_exp, dp_chrom, dp_expcfg, eval_mode) $
         ELSE prelim_MRs = MAKE_ARRAY(n_chrom, /DOUBLE, VALUE=!Values.D_NAN)
 
@@ -377,30 +377,30 @@ PRO dp_res2txt, sel_exp, sel_subst, PATH=path, DEF_PATH=def_path, ALL=all, BRIEF
 
         FOR i=0, N_ELEMENTS(sel_chroms)-1 DO BEGIN
 
-            Chromatogram=FILE_BASENAME(((dp_chrom[sel_exp]).fname)[sel_chroms[i]])
+            Chromatogram = FILE_BASENAME(((dp_chrom[sel_exp]).fname)[sel_chroms[i]])
             Date=jultime2timestring(((dp_chrom[sel_exp]).jdate)[sel_chroms[i]], /ONLYDATE)
             Time=jultime2timestring(((dp_chrom[sel_exp]).jdate)[sel_chroms[i]], /HMSONLY)
-            Sample_Name=((dp_expcfg[sel_exp]).expinfo.s_name)[sel_chroms[i]]
+            Sample_Name = ((dp_expcfg[sel_exp]).expinfo.s_name)[sel_chroms[i]]
 
             CASE eval_mode OF
               0: $
                 BEGIN
                   rR=STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_area.sam_rrsp)[sel_chroms[i]], FORMAT='(D25.6)'), /REMOVE_ALL)
-                  IF rR EQ '-NaN' THEN rR='NaN'
+                  IF rR EQ '-NaN' THEN rR = 'NaN'
                   Block_rR=STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_area.block_rrsp)[sel_chroms[i]], FORMAT='(D25.6)'), /REMOVE_ALL)
-                  IF Block_rR EQ '-NaN' THEN Block_rR='NaN'
+                  IF Block_rR EQ '-NaN' THEN Block_rR = 'NaN'
                   Block_RSD=STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_area.block_rsd)[sel_chroms[i]], FORMAT='(D25.6)'), /REMOVE_ALL)
-                  IF Block_RSD EQ '-NaN' THEN Block_RSD='NaN'
+                  IF Block_RSD EQ '-NaN' THEN Block_RSD = 'NaN'
                   prc_flag=STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_area.prc_flag)[sel_chroms[i]]), /REMOVE_ALL)
                 END
               1: $
                 BEGIN
                   rR=STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_height.sam_rrsp)[sel_chroms[i]], FORMAT='(D25.6)'), /REMOVE_ALL)
-                  IF rR EQ '-NaN' THEN rR='NaN'
+                  IF rR EQ '-NaN' THEN rR = 'NaN'
                   Block_rR=STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_height.block_rrsp)[sel_chroms[i]], FORMAT='(D25.6)'), /REMOVE_ALL)
-                  IF Block_rR EQ '-NaN' THEN Block_rR='NaN'
+                  IF Block_rR EQ '-NaN' THEN Block_rR = 'NaN'
                   Block_RSD=STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_height.block_rsd)[sel_chroms[i]], FORMAT='(D25.6)'), /REMOVE_ALL)
-                  IF Block_RSD EQ '-NaN' THEN Block_RSD='NaN'
+                  IF Block_RSD EQ '-NaN' THEN Block_RSD = 'NaN'
                   prc_flag=STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_height.prc_flag)[sel_chroms[i]]), /REMOVE_ALL)
                 END
             ENDCASE

--- a/Report/dp_res2txt.pro
+++ b/Report/dp_res2txt.pro
@@ -378,34 +378,34 @@ PRO dp_res2txt, sel_exp, sel_subst, PATH=path, DEF_PATH=def_path, ALL=all, BRIEF
         FOR i=0, N_ELEMENTS(sel_chroms)-1 DO BEGIN
 
             Chromatogram = FILE_BASENAME(((dp_chrom[sel_exp]).fname)[sel_chroms[i]])
-            Date=jultime2timestring(((dp_chrom[sel_exp]).jdate)[sel_chroms[i]], /ONLYDATE)
-            Time=jultime2timestring(((dp_chrom[sel_exp]).jdate)[sel_chroms[i]], /HMSONLY)
+            Date = jultime2timestring(((dp_chrom[sel_exp]).jdate)[sel_chroms[i]], /ONLYDATE)
+            Time = jultime2timestring(((dp_chrom[sel_exp]).jdate)[sel_chroms[i]], /HMSONLY)
             Sample_Name = ((dp_expcfg[sel_exp]).expinfo.s_name)[sel_chroms[i]]
 
             CASE eval_mode OF
               0: $
                 BEGIN
-                  rR=STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_area.sam_rrsp)[sel_chroms[i]], FORMAT='(D25.6)'), /REMOVE_ALL)
+                  rR = STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_area.sam_rrsp)[sel_chroms[i]], FORMAT='(D25.6)'), /REMOVE_ALL)
                   IF rR EQ '-NaN' THEN rR = 'NaN'
-                  Block_rR=STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_area.block_rrsp)[sel_chroms[i]], FORMAT='(D25.6)'), /REMOVE_ALL)
+                  Block_rR = STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_area.block_rrsp)[sel_chroms[i]], FORMAT='(D25.6)'), /REMOVE_ALL)
                   IF Block_rR EQ '-NaN' THEN Block_rR = 'NaN'
-                  Block_RSD=STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_area.block_rsd)[sel_chroms[i]], FORMAT='(D25.6)'), /REMOVE_ALL)
+                  Block_RSD = STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_area.block_rsd)[sel_chroms[i]], FORMAT='(D25.6)'), /REMOVE_ALL)
                   IF Block_RSD EQ '-NaN' THEN Block_RSD = 'NaN'
-                  prc_flag=STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_area.prc_flag)[sel_chroms[i]]), /REMOVE_ALL)
+                  prc_flag = STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_area.prc_flag)[sel_chroms[i]]), /REMOVE_ALL)
                 END
               1: $
                 BEGIN
-                  rR=STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_height.sam_rrsp)[sel_chroms[i]], FORMAT='(D25.6)'), /REMOVE_ALL)
+                  rR = STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_height.sam_rrsp)[sel_chroms[i]], FORMAT='(D25.6)'), /REMOVE_ALL)
                   IF rR EQ '-NaN' THEN rR = 'NaN'
-                  Block_rR=STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_height.block_rrsp)[sel_chroms[i]], FORMAT='(D25.6)'), /REMOVE_ALL)
+                  Block_rR = STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_height.block_rrsp)[sel_chroms[i]], FORMAT='(D25.6)'), /REMOVE_ALL)
                   IF Block_rR EQ '-NaN' THEN Block_rR = 'NaN'
-                  Block_RSD=STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_height.block_rsd)[sel_chroms[i]], FORMAT='(D25.6)'), /REMOVE_ALL)
+                  Block_RSD = STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_height.block_rsd)[sel_chroms[i]], FORMAT='(D25.6)'), /REMOVE_ALL)
                   IF Block_RSD EQ '-NaN' THEN Block_RSD = 'NaN'
-                  prc_flag=STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_height.prc_flag)[sel_chroms[i]]), /REMOVE_ALL)
+                  prc_flag = STRCOMPRESS(STRING(((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_height.prc_flag)[sel_chroms[i]]), /REMOVE_ALL)
                 END
             ENDCASE
 
-            prelim_MR=STRCOMPRESS(STRING(prelim_MRs[sel_chroms[i]]), /REMOVE_ALL)
+            prelim_MR = STRCOMPRESS(STRING(prelim_MRs[sel_chroms[i]]), /REMOVE_ALL)
 
             PRINTF, lun, Chromatogram, sep, Date, sep, Time, sep, Sample_Name, sep, rR, sep, $
                          Block_rR, sep, Block_RSD, sep, prc_flag, sep, prelim_MR, FORMAT='(A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A,A)'

--- a/Scripting/dp_dbscript_call.pro
+++ b/Scripting/dp_dbscript_call.pro
@@ -27,7 +27,7 @@ PRO dp_dbscript_call, event, LOAD_1ST_ONLY=load_1st_only, VERBOSE=verbose
 
   COMMON dp_data
 
-  IF NOT KEYWORD_SET(load_1st_only) THEN load_1st_only=0
+  IF NOT KEYWORD_SET(load_1st_only) THEN load_1st_only = 0
 
   ; load database table
   db_info = dp_dbscript_read(FILE=db_file, PATH=path_wd)
@@ -43,8 +43,8 @@ PRO dp_dbscript_call, event, LOAD_1ST_ONLY=load_1st_only, VERBOSE=verbose
     IF n_exp EQ 0 THEN RETURN
 
     IF load_1st_only THEN BEGIN
-      n_exp=1
-      vd_exp=vd_exp[0]
+      n_exp = 1
+      vd_exp = vd_exp[0]
     ENDIF
 
     FOR n=0, n_exp-1 DO BEGIN ; begin loop: N EXPERIMENTS
@@ -62,25 +62,25 @@ PRO dp_dbscript_call, event, LOAD_1ST_ONLY=load_1st_only, VERBOSE=verbose
       ; restore the chrom file
       dp_chrom=dp_restore_chrom(dp_chrom, dp_vers, FNAME=db_info.data[vd_exp[n]].chromdata_path, VERBOSE=verbose)
       dp_chrom=dp_correct_time(dp_chrom, VERBOSE=verbose)
-      chromlist=((dp_chrom[0]).exp_fname)
+      chromlist = ((dp_chrom[0]).exp_fname)
       substlist=LIST(((dp_chrom[0]).subst.name)[*,0])
 
       ; load expinfo
-      instr=db_info.data[vd_exp[n]].EXPINFO_IMPORT_FCT
+      instr = db_info.data[vd_exp[n]].EXPINFO_IMPORT_FCT
       dp_call_expinfo, FNAME=db_info.data[vd_exp[n]].expinfo_path, /OVERWRITE, VERBOSE=verbose
 
       ; update setup info structure
       ITS = {instrument: instr, type: 'undef', spec: 'undef'}
-      tmp_strct=(dp_expcfg)[0]  ; move structure out of list
-      tmp_strct.setup=ITS
-      (dp_expcfg)[0]=TEMPORARY(tmp_strct)  ; put strct with loaded values back into list
+      tmp_strct = (dp_expcfg)[0]  ; move structure out of list
+      tmp_strct.setup = ITS
+      (dp_expcfg)[0] = TEMPORARY(tmp_strct)  ; put strct with loaded values back into list
 
       ; analyse the sequence
       dp_analyse_seq, /QUIET, VERBOSE=verbose
-      samtreats=((dp_expcfg)[0]).sequence.sam_treat
-      samtreats=samtreats[WHERE(STRLEN(samtreats) NE 0)]
-      caltreats=((dp_expcfg)[0]).sequence.cal_treat
-      caltreats=caltreats[WHERE(STRLEN(caltreats) NE 0)]
+      samtreats = ((dp_expcfg)[0]).sequence.sam_treat
+      samtreats = samtreats[WHERE(STRLEN(samtreats) NE 0)]
+      caltreats = ((dp_expcfg)[0]).sequence.cal_treat
+      caltreats = caltreats[WHERE(STRLEN(caltreats) NE 0)]
 
       ; apply default substance names if specified
       IF STRLEN(db_info.data[vd_exp[n]].subst_namedef_path) NE 0 THEN $
@@ -129,13 +129,13 @@ PRO dp_dbscript_call, event, LOAD_1ST_ONLY=load_1st_only, VERBOSE=verbose
               +STRING(hh,format='(I02)')+STRING(mn,format='(I02)')
         cdate = cdate1+'_'+cdate2
 
-        spec_filename=0
-        folder=FILE_DIRNAME(FILE_DIRNAME(db_info.data[vd_exp[n]].chromdata_path))
+        spec_filename = 0
+        folder = FILE_DIRNAME(FILE_DIRNAME(db_info.data[vd_exp[n]].chromdata_path))
         IF KEYWORD_SET(db_info.data[vd_exp[n]].dp_savefile_path) THEN BEGIN
           savepath = db_info.data[vd_exp[n]].dp_savefile_path
           IF STRMATCH(savepath, '*dp_data.dat') EQ 1 THEN BEGIN
-            fname_dp_chrom=savepath
-            spec_filename=1
+            fname_dp_chrom = savepath
+            spec_filename = 1
           ENDIF ELSE BEGIN
             fname_dp_chrom = savepath+'\'+cdate+'_dp_data.dat'
           ENDELSE
@@ -151,7 +151,7 @@ PRO dp_dbscript_call, event, LOAD_1ST_ONLY=load_1st_only, VERBOSE=verbose
         save, dp_expcfg, FILENAME=fname_dp_expcfg
 
         ; save txt reports if desired
-        IF spec_filename THEN savepath=FILE_DIRNAME(savepath)
+        IF spec_filename THEN savepath = FILE_DIRNAME(savepath)
         IF KEYWORD_SET(db_info.data[vd_exp[n]].save_txtreport) THEN BEGIN
           txt_path = savepath+'\dp_txt_report\'
           FILE_MKDIR, txt_path

--- a/Scripting/dp_dbscript_call.pro
+++ b/Scripting/dp_dbscript_call.pro
@@ -174,10 +174,10 @@ PRO dp_dbscript_call, event, LOAD_1ST_ONLY=load_1st_only, VERBOSE=verbose
           pltSaveDst = "K:\KIT_DATA\GHGGC_ReEval\IDL_processing\non_linearity\NL_plots\IDL\"
           saveplot = pltSaveDst + db_info.data[vd_exp[n]].exp_id
           pic_filetype = '.png'
-          
+
           show_plots = 0
-          saveplot = 0 ; remove if plots should be saved to pltSaveDst 
-          
+          saveplot = 0 ; remove if plots should be saved to pltSaveDst
+
           FOR subst=0, N_ELEMENTS((dp_chrom[0].subst)[*,0])-1 DO BEGIN
             fct_dgr = db_info.data[vd_exp[n]].analyse_NL
             nl_strct = dp_nlexp_analyse(fct_dgr, 0, subst, $

--- a/Scripting/dp_dbscript_call.pro
+++ b/Scripting/dp_dbscript_call.pro
@@ -60,10 +60,10 @@ PRO dp_dbscript_call, event, LOAD_1ST_ONLY=load_1st_only, VERBOSE=verbose
       dp_refr_status, message='db script: loading...'+current_exp
 
       ; restore the chrom file
-      dp_chrom=dp_restore_chrom(dp_chrom, dp_vers, FNAME=db_info.data[vd_exp[n]].chromdata_path, VERBOSE=verbose)
-      dp_chrom=dp_correct_time(dp_chrom, VERBOSE=verbose)
+      dp_chrom = dp_restore_chrom(dp_chrom, dp_vers, FNAME=db_info.data[vd_exp[n]].chromdata_path, VERBOSE=verbose)
+      dp_chrom = dp_correct_time(dp_chrom, VERBOSE=verbose)
       chromlist = ((dp_chrom[0]).exp_fname)
-      substlist=LIST(((dp_chrom[0]).subst.name)[*,0])
+      substlist = LIST(((dp_chrom[0]).subst.name)[*,0])
 
       ; load expinfo
       instr = db_info.data[vd_exp[n]].EXPINFO_IMPORT_FCT
@@ -92,20 +92,20 @@ PRO dp_dbscript_call, event, LOAD_1ST_ONLY=load_1st_only, VERBOSE=verbose
 
       ; load dp_calmrs if specified
       IF STRLEN(db_info.data[vd_exp[n]].dp_calmrs_path) NE 0 THEN BEGIN
-        mrs_strct=dp_read_calmrs(DEF_FILE=db_info.data[vd_exp[n]].dp_calmrs_path, VERBOSE=verbose)
+        mrs_strct = dp_read_calmrs(DEF_FILE=db_info.data[vd_exp[n]].dp_calmrs_path, VERBOSE=verbose)
         dp_apply_calmrs, 0, mrs_strct, PATH=path_wd, VERBOSE=verbose
       ENDIF
 
       ; load dp_tgtmrs if specified
       IF STRLEN(db_info.data[vd_exp[n]].dp_tgtmrs_path) NE 0 THEN BEGIN
-        tgt_strct=dp_read_tgtmrs(DEF_FILE=db_info.data[vd_exp[n]].dp_tgtmrs_path, VERBOSE=verbose)
+        tgt_strct = dp_read_tgtmrs(DEF_FILE=db_info.data[vd_exp[n]].dp_tgtmrs_path, VERBOSE=verbose)
         dp_apply_tgtmrs, 0, tgt_strct, PATH=path_wd, VERBOSE=verbose
       ENDIF
 
       ; load dp_instr_prc if specified
       IF STRLEN(db_info.data[vd_exp[n]].dp_instr_prc_path) NE 0 THEN BEGIN
-        prc_strct=dp_read_instrprc(0, chromlist[0], substlist, $
-                                   DEF_FILE=db_info.data[vd_exp[n]].dp_instr_prc_path, VERBOSE=verbose)
+        prc_strct = dp_read_instrprc(0, chromlist[0], substlist, $
+                                     DEF_FILE=db_info.data[vd_exp[n]].dp_instr_prc_path, VERBOSE=verbose)
         dp_apply_instrprc, 0, PRC_STRCT=prc_strct, /QUIET, VERBOSE=verbose
       ENDIF
 
@@ -140,9 +140,9 @@ PRO dp_dbscript_call, event, LOAD_1ST_ONLY=load_1st_only, VERBOSE=verbose
             fname_dp_chrom = savepath+'\'+cdate+'_dp_data.dat'
           ENDELSE
         ENDIF ELSE BEGIN
-          savepath = folder+'\__IAU_DATAPROC_save'
+          savepath = folder + '\__IAU_DATAPROC_save'
           db_info.data[vd_exp[n]].dp_savefile_path = savepath
-          fname_dp_chrom = savepath+'\'+cdate+'_dp_data.dat'
+          fname_dp_chrom = savepath + '\' + cdate + '_dp_data.dat'
         ENDELSE
 
         FILE_MKDIR, FILE_DIRNAME(fname_dp_chrom)
@@ -153,7 +153,7 @@ PRO dp_dbscript_call, event, LOAD_1ST_ONLY=load_1st_only, VERBOSE=verbose
         ; save txt reports if desired
         IF spec_filename THEN savepath = FILE_DIRNAME(savepath)
         IF KEYWORD_SET(db_info.data[vd_exp[n]].save_txtreport) THEN BEGIN
-          txt_path = savepath+'\dp_txt_report\'
+          txt_path = savepath + '\dp_txt_report\'
           FILE_MKDIR, txt_path
           dp_res2txt, 0, 0, DEF_PATH=txt_path, /ALL, /BRIEF, VERBOSE=verbose
         ENDIF

--- a/Scripting/dp_dbscript_chk.pro
+++ b/Scripting/dp_dbscript_chk.pro
@@ -11,7 +11,7 @@
 ;------------------------------------------------------------------------------------------------------------------------
 FUNCTION dp_dbscript_chk, dp_dbstrct, LOUD=loud, N_TESTED=n_tested
 
-  ; file approved if n_tested=n_passed
+  ; file approved if n_tested = n_passed
   n_tested = 0
   n_passed = 0
 
@@ -48,8 +48,8 @@ FUNCTION dp_dbscript_chk, dp_dbstrct, LOUD=loud, N_TESTED=n_tested
   IF NOT no_exp THEN BEGIN
     ; exp_id unique?
     n_tested = n_tested + 1
-    str=dp_dbstrct.data.exp_id
-    str[uniq(str)]='-unique-'
+    str = dp_dbstrct.data.exp_id
+    str[uniq(str)] = '-unique-'
     w_not_uniq=WHERE(str NE '-unique-', nvd)
     IF nvd GT 0 THEN BEGIN
       msg = [msg, '- found double experiment id(s):']
@@ -58,7 +58,7 @@ FUNCTION dp_dbscript_chk, dp_dbstrct, LOUD=loud, N_TESTED=n_tested
 
     ; data_import_fct is allowed?
     n_tested = n_tested + 1
-    str=dp_dbstrct.data.EXPINFO_IMPORT_FCT
+    str = dp_dbstrct.data.EXPINFO_IMPORT_FCT
     def_fct=['Lab_BenchTOF','Lab_QP/SFMS','FASTOF','GhOST_MS','GhOST_ECD','AED','GHGGC_ECD/FID']
     str_match = LONARR(N_ELEMENTS(str))
     FOR i=0, N_ELEMENTS(str)-1 DO BEGIN

--- a/Table/dp_sel_meas_table_ini.pro
+++ b/Table/dp_sel_meas_table_ini.pro
@@ -60,7 +60,7 @@ PRO dp_sel_meas_table_ini, sel_exp, sel_subst
                 2.0 $;     USE_FLAG
                 ]
 
-  tbl_base = WIDGET_BASE(TITLE=((dp_chrom[sel_exp]).subst[sel_subst].name)[0]+' : select measurements...')
+  tbl_base = WIDGET_BASE(TITLE = ((dp_chrom[sel_exp]).subst[sel_subst].name)[0]+' : select measurements...')
 
   tbl_id=WIDGET_TABLE(tbl_base, VALUE=tblval, COLUMN_LABELS=TAG_NAMES(ref_seltable), SCR_XSIZE=18, SCR_YSIZE=26, $
                       XSIZE=N_ELEMENTS(column_width), COLUMN_WIDTH=column_width, units=2, /ROW_MAJOR, /SCROLL, $

--- a/Table/dp_sel_meas_table_ini.pro
+++ b/Table/dp_sel_meas_table_ini.pro
@@ -44,7 +44,7 @@ PRO dp_sel_meas_table_ini, sel_exp, sel_subst
                   }
 
 
-  tblval=!NULL
+  tblval = !NULL
   tblval=REPLICATE(ref_seltable, N_ELEMENTS(dp_chrom[sel_exp]))
 
   tblval.NUMBER       = 1+INDGEN(N_ELEMENTS(dp_chrom[sel_exp]))
@@ -60,7 +60,7 @@ PRO dp_sel_meas_table_ini, sel_exp, sel_subst
                 2.0 $;     USE_FLAG
                 ]
 
-  tbl_base=WIDGET_BASE(TITLE=((dp_chrom[sel_exp]).subst[sel_subst].name)[0]+' : select measurements...')
+  tbl_base = WIDGET_BASE(TITLE=((dp_chrom[sel_exp]).subst[sel_subst].name)[0]+' : select measurements...')
 
   tbl_id=WIDGET_TABLE(tbl_base, VALUE=tblval, COLUMN_LABELS=TAG_NAMES(ref_seltable), SCR_XSIZE=18, SCR_YSIZE=26, $
                       XSIZE=N_ELEMENTS(column_width), COLUMN_WIDTH=column_width, units=2, /ROW_MAJOR, /SCROLL, $

--- a/Table/dp_show_carryover_def.pro
+++ b/Table/dp_show_carryover_def.pro
@@ -11,7 +11,7 @@ PRO dp_show_carryover_def, sel_exp
   COMMON DP_DATA
 
   IF *(dp_expcfg[sel_exp]).carryover.substance EQ !NULL THEN BEGIN
-    msg=DIALOG_MESSAGE('No carry-over config found for selected experiment.')
+    msg = DIALOG_MESSAGE('No carry-over config found for selected experiment.')
     RETURN
   ENDIF
 
@@ -50,7 +50,7 @@ PRO dp_show_carryover_def, sel_exp
 
   column_width = [160,100,100,100,100,100,100]
 
-  mainbase = WIDGET_BASE(title='Carry-Over Table')
+  mainbase = WIDGET_BASE(title = 'Carry-Over Table')
   ID = WIDGET_TABLE(mainbase, VALUE=value, COLUMN_WIDTH=column_width, ALIGNMENT=0)
 
   WIDGET_CONTROL, ID, /REALIZE

--- a/Table/dp_show_mrtable.pro
+++ b/Table/dp_show_mrtable.pro
@@ -46,7 +46,7 @@ PRO dp_show_mrtable, sel_exp
 
   column_width = [150,100,100,100,100,150,150]
 
-  mainbase = WIDGET_BASE(title='Cal MR Table')
+  mainbase = WIDGET_BASE(title = 'Cal MR Table')
   ID = WIDGET_TABLE(mainbase, VALUE=value, COLUMN_WIDTH=column_width, ALIGNMENT=0)
 
   WIDGET_CONTROL, ID, /REALIZE

--- a/Table/dp_show_prctable.pro
+++ b/Table/dp_show_prctable.pro
@@ -11,7 +11,7 @@ PRO dp_show_prctable, sel_exp
   COMMON DP_DATA
 
   IF ((dp_expcfg[sel_exp]).instr_prc.instrument) EQ '' THEN BEGIN
-    msg=DIALOG_MESSAGE('No loaded PRC data found.')
+    msg = DIALOG_MESSAGE('No loaded PRC data found.')
     RETURN
   ENDIF
 
@@ -44,7 +44,7 @@ PRO dp_show_prctable, sel_exp
 
   column_width=[150,100,100,100,100,150]
 
-  mainbase=WIDGET_BASE(title='Loaded Prc Table')
+  mainbase = WIDGET_BASE(title='Loaded Prc Table')
   ID=WIDGET_TABLE(mainbase, VALUE=value, COLUMN_WIDTH=column_width, ALIGNMENT=0)
 
   WIDGET_CONTROL, ID, /REALIZE

--- a/Table/dp_show_prctable.pro
+++ b/Table/dp_show_prctable.pro
@@ -44,7 +44,7 @@ PRO dp_show_prctable, sel_exp
 
   column_width=[150,100,100,100,100,150]
 
-  mainbase = WIDGET_BASE(title='Loaded Prc Table')
+  mainbase = WIDGET_BASE(title = 'Loaded Prc Table')
   ID=WIDGET_TABLE(mainbase, VALUE=value, COLUMN_WIDTH=column_width, ALIGNMENT=0)
 
   WIDGET_CONTROL, ID, /REALIZE

--- a/Table/dp_show_restable.pro
+++ b/Table/dp_show_restable.pro
@@ -18,8 +18,8 @@ PRO dp_show_restable, sel_exp, sel_subst, BRIEF=brief
   mode_string = (['AREA', 'HEIGHT'])[eval_mode]
 
   IF ((dp_expcfg[sel_exp]).cal_mrs.canister) NE '' THEN $
-    prelim_MRs=dp_calc_mrs(subst_name, sel_subst, sel_exp, dp_chrom, dp_expcfg, eval_mode) $
-      ELSE prelim_MRs=MAKE_ARRAY(n_chrom, /DOUBLE, VALUE=!Values.D_NAN)
+    prelim_MRs = dp_calc_mrs(subst_name, sel_subst, sel_exp, dp_chrom, dp_expcfg) $
+      ELSE prelim_MRs = MAKE_ARRAY(n_chrom, /DOUBLE, VALUE=!Values.D_NAN)
 
   IF brief THEN BEGIN ;++++++++++++++++++++++++++++++++++++++++BRIEF+++
 
@@ -280,7 +280,7 @@ PRO dp_show_restable, sel_exp, sel_subst, BRIEF=brief
   ENDELSE
 
 
-  mainbase = WIDGET_BASE(title='Results for: '+((dp_chrom[sel_exp]).subst[sel_subst].name)[0])
+  mainbase = WIDGET_BASE(title = 'Results for: '+((dp_chrom[sel_exp]).subst[sel_subst].name)[0])
 
   ID=WIDGET_TABLE(mainbase, VALUE=tblval, COLUMN_LABELS=col_labels, SCR_XSIZE=scr_xsize, SCR_YSIZE=scr_ysize, $
                   XSIZE=N_ELEMENTS(column_width), COLUMN_WIDTH=column_width, units=2, /ROW_MAJOR, /SCROLL, $

--- a/Table/dp_show_restable.pro
+++ b/Table/dp_show_restable.pro
@@ -18,7 +18,7 @@ PRO dp_show_restable, sel_exp, sel_subst, BRIEF=brief
   mode_string = (['AREA', 'HEIGHT'])[eval_mode]
 
   IF ((dp_expcfg[sel_exp]).cal_mrs.canister) NE '' THEN $
-    prelim_MRs=dp_calc_mrs(subst_name, sel_subst, sel_exp, dp_chrom, dp_expcfg) $
+    prelim_MRs=dp_calc_mrs(subst_name, sel_subst, sel_exp, dp_chrom, dp_expcfg, eval_mode) $
       ELSE prelim_MRs=MAKE_ARRAY(n_chrom, /DOUBLE, VALUE=!Values.D_NAN)
 
   IF brief THEN BEGIN ;++++++++++++++++++++++++++++++++++++++++BRIEF+++

--- a/Table/dp_show_restable.pro
+++ b/Table/dp_show_restable.pro
@@ -10,7 +10,7 @@ PRO dp_show_restable, sel_exp, sel_subst, BRIEF=brief
 
   COMMON DP_DATA
 
-  IF NOT KEYWORD_SET(brief) THEN brief=0
+  IF NOT KEYWORD_SET(brief) THEN brief = 0
 
   n_chrom = N_ELEMENTS((dp_chrom[sel_exp]))
   subst_name = (substlist[sel_exp])[sel_subst]
@@ -56,7 +56,7 @@ PRO dp_show_restable, sel_exp, sel_subst, BRIEF=brief
                       PRC_FLAG     : 0L, $
                       PRELIM_MR    : ''       }
 
-    tblval=!NULL
+    tblval = !NULL
     tblval=REPLICATE(ref_restable, n_sam)
 
     tblval.NUMBER       = (1+INDGEN(N_ELEMENTS(dp_chrom[sel_exp])))[w]
@@ -137,12 +137,12 @@ PRO dp_show_restable, sel_exp, sel_subst, BRIEF=brief
                   2.4     ]; PRELIM_MR
 
 
-    scr_xsize=24
-    scr_ysize=20
+    scr_xsize = 24
+    scr_ysize = 20
 
-    col_labels=TAG_NAMES(ref_restable)
-    col_labels[6]=col_labels[6]+'[%]'
-    col_labels[7]=col_labels[7]+'[%]'
+    col_labels = TAG_NAMES(ref_restable)
+    col_labels[6] = col_labels[6]+'[%]'
+    col_labels[7] = col_labels[7]+'[%]'
 
   ENDIF ELSE BEGIN ;++++++++++++++++++++++++++++++++++++++++DETAILED+++
 
@@ -172,7 +172,7 @@ PRO dp_show_restable, sel_exp, sel_subst, BRIEF=brief
                       PRC_FLAG     : 0L, $
                       PRELIM_MR    : ''       }
 
-    tblval=!NULL
+    tblval = !NULL
     tblval=REPLICATE(ref_restable, N_ELEMENTS(dp_chrom[sel_exp]))
 
     tblval.NUMBER       = 1+INDGEN(N_ELEMENTS(dp_chrom[sel_exp]))
@@ -228,7 +228,7 @@ PRO dp_show_restable, sel_exp, sel_subst, BRIEF=brief
 
 
 
-    t_precon=STRARR(n_chrom)
+    t_precon = STRARR(n_chrom)
     FOR i=0, n_chrom-1 DO BEGIN
       caldat, SYSTIME(/JULIAN), mm, dd, yyyy, hh0, mn0, ss0
       caldat, SYSTIME(/JULIAN)+(tblval.DT_PRECON)[i], mm, dd, yyyy, hh1, mn1, ss1
@@ -269,18 +269,18 @@ PRO dp_show_restable, sel_exp, sel_subst, BRIEF=brief
                   2.4     ]; PRELIM_MR
 
 
-    scr_xsize=39
-    scr_ysize=20
+    scr_xsize = 39
+    scr_ysize = 20
 
-    col_labels=TAG_NAMES(ref_restable)
-    col_labels[12]=col_labels[12]+'[%]'
-    col_labels[13]=col_labels[13]+'[%]'
-    col_labels[14]=col_labels[14]+'[%]'
+    col_labels = TAG_NAMES(ref_restable)
+    col_labels[12] = col_labels[12]+'[%]'
+    col_labels[13] = col_labels[13]+'[%]'
+    col_labels[14] = col_labels[14]+'[%]'
 
   ENDELSE
 
 
-  mainbase=WIDGET_BASE(title='Results for: '+((dp_chrom[sel_exp]).subst[sel_subst].name)[0])
+  mainbase = WIDGET_BASE(title='Results for: '+((dp_chrom[sel_exp]).subst[sel_subst].name)[0])
 
   ID=WIDGET_TABLE(mainbase, VALUE=tblval, COLUMN_LABELS=col_labels, SCR_XSIZE=scr_xsize, SCR_YSIZE=scr_ysize, $
                   XSIZE=N_ELEMENTS(column_width), COLUMN_WIDTH=column_width, units=2, /ROW_MAJOR, /SCROLL, $

--- a/Table/dp_show_tgtmrtable.pro
+++ b/Table/dp_show_tgtmrtable.pro
@@ -11,23 +11,23 @@ PRO dp_show_tgtmrtable, sel_exp
 
   IF PTR_VALID((dp_expcfg[sel_exp]).tgt_mrs.tgt_name) THEN BEGIN
     IF *((dp_expcfg[sel_exp]).tgt_mrs.tgt_name) NE !NULL THEN BEGIN
-      TGT_NAME=*((dp_expcfg[sel_exp]).tgt_mrs.tgt_name)
-      SUBSTANCE=*((dp_expcfg[sel_exp]).tgt_mrs.SUBSTANCE)
-      MR=*((dp_expcfg[sel_exp]).tgt_mrs.MR_PPT)
-      UNC_abs=*((dp_expcfg[sel_exp]).tgt_mrs.UNC_PPT)
-      UNC_REL=*((dp_expcfg[sel_exp]).tgt_mrs.UNC_REL)
-      SCALE=*((dp_expcfg[sel_exp]).tgt_mrs.SCALE)
-      COMMENT=*((dp_expcfg[sel_exp]).tgt_mrs.COMMENT)
+      TGT_NAME = *((dp_expcfg[sel_exp]).tgt_mrs.tgt_name)
+      SUBSTANCE = *((dp_expcfg[sel_exp]).tgt_mrs.SUBSTANCE)
+      MR = *((dp_expcfg[sel_exp]).tgt_mrs.MR_PPT)
+      UNC_abs = *((dp_expcfg[sel_exp]).tgt_mrs.UNC_PPT)
+      UNC_REL = *((dp_expcfg[sel_exp]).tgt_mrs.UNC_REL)
+      SCALE = *((dp_expcfg[sel_exp]).tgt_mrs.SCALE)
+      COMMENT = *((dp_expcfg[sel_exp]).tgt_mrs.COMMENT)
       IF (*((dp_expcfg[sel_exp]).tgt_mrs.UNIT)) NE !NULL THEN $
         UNIT=*((dp_expcfg[sel_exp]).tgt_mrs.UNIT) $
       ELSE UNIT=STRARR(N_ELEMENTS(COMMENT))
     ENDIF ELSE BEGIN
-      msg=DIALOG_MESSAGE('No Tgt MR data found.')
+      msg = DIALOG_MESSAGE('No Tgt MR data found.')
       RETURN
     ENDELSE
 
     column_labels=['Substance','MR','UNC_abs','UNC_rel','Unit','Scale','Comment']
-    row_labels=TGT_NAME
+    row_labels = TGT_NAME
 
     nl_hdr  = 0
     width   = 7
@@ -46,7 +46,7 @@ PRO dp_show_tgtmrtable, sel_exp
 
     column_width=[150,100,100,100,100,150,150]
 
-    mainbase=WIDGET_BASE(title='Tgt MR Table')
+    mainbase = WIDGET_BASE(title='Tgt MR Table')
     ID=WIDGET_TABLE(mainbase, VALUE=value, COLUMN_WIDTH=column_width, ALIGNMENT=0, $
                     COLUMN_LABELS=column_labels, ROW_LABELS=row_labels)
 

--- a/Table/dp_show_tgtmrtable.pro
+++ b/Table/dp_show_tgtmrtable.pro
@@ -46,7 +46,7 @@ PRO dp_show_tgtmrtable, sel_exp
 
     column_width=[150,100,100,100,100,150,150]
 
-    mainbase = WIDGET_BASE(title='Tgt MR Table')
+    mainbase = WIDGET_BASE(title = 'Tgt MR Table')
     ID=WIDGET_TABLE(mainbase, VALUE=value, COLUMN_WIDTH=column_width, ALIGNMENT=0, $
                     COLUMN_LABELS=column_labels, ROW_LABELS=row_labels)
 

--- a/Table/dp_show_treatcfgtable.pro
+++ b/Table/dp_show_treatcfgtable.pro
@@ -36,7 +36,7 @@ PRO dp_show_treatcfgtable, sel_exp
 
   column_width=[150,100,100,100]
 
-  mainbase = WIDGET_BASE(title='Treatment Config Table')
+  mainbase = WIDGET_BASE(title = 'Treatment Config Table')
   ID=WIDGET_TABLE(mainbase, VALUE=value, COLUMN_WIDTH=column_width, COLUMN_LABELS=hdr, ALIGNMENT=0)
 
   WIDGET_CONTROL, ID, /REALIZE

--- a/Table/dp_show_treatcfgtable.pro
+++ b/Table/dp_show_treatcfgtable.pro
@@ -11,12 +11,12 @@ PRO dp_show_treatcfgtable, sel_exp
   COMMON DP_DATA
 
   IF NOT PTR_VALID((dp_expcfg[sel_exp]).treatcfg.substance) THEN BEGIN
-    msg=DIALOG_MESSAGE('No loaded treatment config found.')
+    msg = DIALOG_MESSAGE('No loaded treatment config found.')
     RETURN
   ENDIF
 
   IF (*(dp_expcfg[sel_exp]).treatcfg.substance) EQ !NULL THEN BEGIN
-    msg=DIALOG_MESSAGE('No loaded treatment config found.')
+    msg = DIALOG_MESSAGE('No loaded treatment config found.')
     RETURN
   ENDIF
 
@@ -36,7 +36,7 @@ PRO dp_show_treatcfgtable, sel_exp
 
   column_width=[150,100,100,100]
 
-  mainbase=WIDGET_BASE(title='Treatment Config Table')
+  mainbase = WIDGET_BASE(title='Treatment Config Table')
   ID=WIDGET_TABLE(mainbase, VALUE=value, COLUMN_WIDTH=column_width, COLUMN_LABELS=hdr, ALIGNMENT=0)
 
   WIDGET_CONTROL, ID, /REALIZE

--- a/Tools_data/dp_calc_carryover.pro
+++ b/Tools_data/dp_calc_carryover.pro
@@ -17,7 +17,7 @@ FUNCTION dp_calc_carryover, norm_resp, sequence, carryover_strct, subst_name
       id_sam = 1
       id_tgt = 2 ; tgt treated as sample in calulations here!
 
-      corr_norm_resp=norm_resp ; set equal to input so that no additional NaNs are introduced
+      corr_norm_resp = norm_resp ; set equal to input so that no additional NaNs are introduced
       FOR n=1, N_ELEMENTS(norm_resp)-1 DO BEGIN
         sect_id = (sequence.id)[n-1:n]
         sect_rsp = norm_resp[n-1:n]

--- a/Tools_data/dp_calc_mrs.pro
+++ b/Tools_data/dp_calc_mrs.pro
@@ -7,16 +7,11 @@
 ;
 ;-
 ;------------------------------------------------------------------------------------------------------------------------
-FUNCTION dp_calc_mrs, subst_name, sel_name, sel_exp, dp_chrom, dp_expcfg, $
-                      EVAL_MODE=eval_mode
+FUNCTION dp_calc_mrs, subst_name, sel_name, sel_exp, dp_chrom, dp_expcfg, eval_mode
 
   n_chrom = N_ELEMENTS((dp_chrom[sel_exp]))
 
   sam_treat = (dp_chrom[0].subst[0].rres.sam_treat)[0]
-
-  IF NOT KEYWORD_SET(eval_mode) THEN $
-    eval_mode = ((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_select)[0] $
-      ELSE eval_mode = 0 ; default area
 
   mrs_array = MAKE_ARRAY(n_chrom, /DOUBLE, VALUE=!Values.D_NAN)
   mrs = mrs_array
@@ -26,6 +21,7 @@ FUNCTION dp_calc_mrs, subst_name, sel_name, sel_exp, dp_chrom, dp_expcfg, $
     IF w_subst[0] EQ -1 THEN RETURN, mrs_array
   ENDIF ELSE RETURN, mrs_array
 
+  ;print, "dp_calc_mrs eval mode:", eval_mode
 
   CASE eval_mode OF ; 0 area / 1 height // bl stands for "block" here...
     0: $

--- a/Tools_data/dp_calc_mrs.pro
+++ b/Tools_data/dp_calc_mrs.pro
@@ -7,11 +7,12 @@
 ;
 ;-
 ;------------------------------------------------------------------------------------------------------------------------
-FUNCTION dp_calc_mrs, subst_name, sel_name, sel_exp, dp_chrom, dp_expcfg, eval_mode
+FUNCTION dp_calc_mrs, subst_name, sel_name, sel_exp, dp_chrom, dp_expcfg
 
   n_chrom = N_ELEMENTS((dp_chrom[sel_exp]))
 
   sam_treat = (dp_chrom[0].subst[0].rres.sam_treat)[0]
+  eval_mode = ((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_select)[0]
 
   mrs_array = MAKE_ARRAY(n_chrom, /DOUBLE, VALUE=!Values.D_NAN)
   mrs = mrs_array
@@ -21,7 +22,6 @@ FUNCTION dp_calc_mrs, subst_name, sel_name, sel_exp, dp_chrom, dp_expcfg, eval_m
     IF w_subst[0] EQ -1 THEN RETURN, mrs_array
   ENDIF ELSE RETURN, mrs_array
 
-  ;print, "dp_calc_mrs eval mode:", eval_mode
 
   CASE eval_mode OF ; 0 area / 1 height // bl stands for "block" here...
     0: $

--- a/Tools_data/dp_nlexp_analyse.pro
+++ b/Tools_data/dp_nlexp_analyse.pro
@@ -27,7 +27,7 @@ FUNCTION dp_nlexp_analyse, fct_dgr, sel_exp, sel_subst, FORCE_ZERO=force_zero, $
   IF NOT KEYWORD_SET(estimate_cal) THEN estimate_cal = 0
   IF NOT KEYWORD_SET(saveplot) THEN saveplot = 0
   IF NOT KEYWORD_SET(pic_filetype) THEN pic_filetype = '.ps'
-  status=0
+  status = 0
 
   ; check if cal and tgt mrs loaded
   IF PTR_VALID((dp_expcfg[sel_exp]).tgt_mrs.mr_ppt) THEN BEGIN
@@ -43,8 +43,8 @@ FUNCTION dp_nlexp_analyse, fct_dgr, sel_exp, sel_subst, FORCE_ZERO=force_zero, $
   IF *(dp_expcfg[sel_exp]).cal_mrs.mr_ppt EQ !NULL $
     THEN BEGIN
       IF loud THEN msg=DIALOG_MESSAGE('No Cal MRs found, switching to Cal-MR estimation.', /INFORMATION)
-      estimate_cal=1
-    ENDIF ; ELSE estimate_cal=estimate_cal
+      estimate_cal = 1
+    ENDIF ; ELSE estimate_cal = estimate_cal
 
   ; check if sample treatment is 'individual'
   treat_arr = (dp_chrom[sel_exp]).subst.rres.sam_treat
@@ -72,7 +72,7 @@ FUNCTION dp_nlexp_analyse, fct_dgr, sel_exp, sel_subst, FORCE_ZERO=force_zero, $
   ENDELSE
 
   tgt_substs = *(dp_expcfg[sel_exp]).tgt_mrs.substance
-  tmp=tgt_substs[SORT(tgt_substs)]
+  tmp = tgt_substs[SORT(tgt_substs)]
   tgt_substs = tmp[uniq(tmp)]
 
   w_s_cal = WHERE(cal_substs EQ subst)
@@ -121,8 +121,8 @@ FUNCTION dp_nlexp_analyse, fct_dgr, sel_exp, sel_subst, FORCE_ZERO=force_zero, $
         IF NOT estimate_cal THEN BEGIN
           mrs[*,i]=dp_calc_mrs(match_substs[i], sel_name, sel_exp, dp_chrom, dp_expcfg, eval_mode)
           w_subst=WHERE(*(dp_expcfg[sel_exp]).cal_mrs.substance EQ match_substs[i], n_match_mr)
-          cal_MR_spec=(*(dp_expcfg[sel_exp]).cal_mrs.mr_ppt)[w_subst[0]]
-          cal_MR_err=(*(dp_expcfg[sel_exp]).cal_mrs.unc_ppt)[w_subst[0]]
+          cal_MR_spec = (*(dp_expcfg[sel_exp]).cal_mrs.mr_ppt)[w_subst[0]]
+          cal_MR_err = (*(dp_expcfg[sel_exp]).cal_mrs.unc_ppt)[w_subst[0]]
         ENDIF ELSE BEGIN
           cal_MR_spec = !VALUES.D_NAN
           cal_MR_err = !VALUES.D_NAN
@@ -176,7 +176,7 @@ FUNCTION dp_nlexp_analyse, fct_dgr, sel_exp, sel_subst, FORCE_ZERO=force_zero, $
         ENDIF ELSE $
             w_fin = WHERE(FINITE(delta_mrs[*,i]) EQ 1, n_fin)
 
-        IF n_fin LT 2 THEN status=-1
+        IF n_fin LT 2 THEN status = -1
 
         sort_ix = SORT((tgt_mrs[*,i])[w_fin])
         tgt_mr_range = [MIN(((tgt_mrs[*,i])[w_fin])[sort_ix], /NAN),MAX(((tgt_mrs[*,i])[w_fin])[sort_ix], /NAN)]
@@ -194,15 +194,15 @@ FUNCTION dp_nlexp_analyse, fct_dgr, sel_exp, sel_subst, FORCE_ZERO=force_zero, $
         measure_errors[WHERE(measure_errors LT 0.0001)] = 0.0001
 
         IF estimate_cal THEN BEGIN
-          XTITLE='relative detector response'
-          YTITLE='target MR'
-          p2_name='est_Cal_MR'
-          x=((samples_rR)[w_fin])[sort_ix]
+          XTITLE = 'relative detector response'
+          YTITLE = 'target MR'
+          p2_name = 'est_Cal_MR'
+          x = ((samples_rR)[w_fin])[sort_ix]
           y=((tgt_mrs[*,i])[w_fin])[sort_ix]
         ENDIF ELSE BEGIN
-          XTITLE='linear MR'
-          YTITLE='delta MR'
-          p2_name='corr. values'
+          XTITLE = 'linear MR'
+          YTITLE = 'delta MR'
+          p2_name = 'corr. values'
           x=((mrs[*,i])[w_fin])[sort_ix]
           y=((delta_mrs[*,i])[w_fin])[sort_ix]
         ENDELSE
@@ -210,11 +210,11 @@ FUNCTION dp_nlexp_analyse, fct_dgr, sel_exp, sel_subst, FORCE_ZERO=force_zero, $
         ; derive mean values, different number of measurements per target are accounted for
         ; through the error of the mean SD/SQRT(n)
         snames=((s_names_arr[*,i])[w_fin])[sort_ix]
-        x_means=DBLARR(N_ELEMENTS(u_tgt))*!VALUES.D_NAN
-        y_means=DBLARR(N_ELEMENTS(u_tgt))*!VALUES.D_NAN
-        tgt_mrs_means=DBLARR(N_ELEMENTS(u_tgt))*!VALUES.D_NAN
-        e_means=DBLARR(N_ELEMENTS(u_tgt))*!VALUES.D_NAN
-        e_plot=DBLARR(N_ELEMENTS(u_tgt))*!VALUES.D_NAN
+        x_means = DBLARR(N_ELEMENTS(u_tgt))*!VALUES.D_NAN
+        y_means = DBLARR(N_ELEMENTS(u_tgt))*!VALUES.D_NAN
+        tgt_mrs_means = DBLARR(N_ELEMENTS(u_tgt))*!VALUES.D_NAN
+        e_means = DBLARR(N_ELEMENTS(u_tgt))*!VALUES.D_NAN
+        e_plot = DBLARR(N_ELEMENTS(u_tgt))*!VALUES.D_NAN
         FOR k=0, N_ELEMENTS(u_tgt)-1 DO BEGIN
           w_tgt = WHERE(snames EQ u_tgt[k], nw)
           IF nw GT 0 THEN BEGIN
@@ -226,14 +226,14 @@ FUNCTION dp_nlexp_analyse, fct_dgr, sel_exp, sel_subst, FORCE_ZERO=force_zero, $
         ENDFOR
 
   ; +++ MOD
-  ;      IF match_substs[0] EQ 'SF6' THEN force_zero=1
-  ;      measure_errors[*]=0.01D
+  ;      IF match_substs[0] EQ 'SF6' THEN force_zero = 1
+  ;      measure_errors[*] = 0.01D
         w_fin_x=WHERE(FINITE(x_means) EQ 1, n_fin_x)
         IF n_fin_x GT 0 THEN BEGIN
-          x=x_means[w_fin_x]
-          y=y_means[w_fin_x]
-          measure_errors=e_means[w_fin_x]
-          e_plot=e_plot[w_fin_x]
+          x = x_means[w_fin_x]
+          y = y_means[w_fin_x]
+          measure_errors = e_means[w_fin_x]
+          e_plot = e_plot[w_fin_x]
         ENDIF
   ; +++
 
@@ -263,7 +263,7 @@ FUNCTION dp_nlexp_analyse, fct_dgr, sel_exp, sel_subst, FORCE_ZERO=force_zero, $
             fit_x = interpol([MIN(x, /NAN),MAX(x, /NAN)], 200)
             fit_smooth = polyfit_get_ydata(fct_dgr, fit_x, parms)
             dev_to_fit = polyfit_get_ydata(fct_dgr, x, parms) - y
-            n_fold_sd=1D
+            n_fold_sd = 1D
 
   ; +++ MOD
   ;        ; derive ascension angle alpha from polyfit parms
@@ -298,8 +298,8 @@ FUNCTION dp_nlexp_analyse, fct_dgr, sel_exp, sel_subst, FORCE_ZERO=force_zero, $
   ;                         [mean(y-fit_delta)+n_fold_sd*stddev(y-fit_delta,/NAN),mean(y-fit_delta)-n_fold_sd*stddev(y-fit_delta,/NAN)], 1)
   ;        p_lower=poly_fit([MIN(x,ix_min),MAX(x,ix_max)], $
   ;                         [mean(y-fit_delta)-n_fold_sd*stddev(y-fit_delta,/NAN),mean(y-fit_delta)+n_fold_sd*stddev(y-fit_delta,/NAN)], 1)
-  ;        x_bound_0=x
-  ;        x_bound_1=x
+  ;        x_bound_0 = x
+  ;        x_bound_1 = x
   ;        y_upper=polyfit_get_ydata(1, [280D,x_bound_0], p_upper)
   ;        y_lower=polyfit_get_ydata(1, [280D,x_bound_1], p_lower)
   ; +++
@@ -384,7 +384,7 @@ FUNCTION dp_nlexp_analyse, fct_dgr, sel_exp, sel_subst, FORCE_ZERO=force_zero, $
                 l = legend(TARGET=[p0,p1,p2], /DATA, /AUTO_TEXT_COLOR)
                 l.position = [0.99,0.99]
 
-                textfontsize=14
+                textfontsize = 14
                 t0 = text(0.02,0.95, match_substs[i], TARGET=p0, FONT_SIZE=textfontsize, FONT_STYLE='bf')
                 t1 = text(0.26,0.95, exp_fname, TARGET=p0, FONT_SIZE=textfontsize, FONT_STYLE='bf')
                 t2 = text(0.52,0.95, 'Cal: '+cal_name, TARGET=p0, FONT_SIZE=textfontsize, FONT_STYLE='bf')
@@ -396,20 +396,20 @@ FUNCTION dp_nlexp_analyse, fct_dgr, sel_exp, sel_subst, FORCE_ZERO=force_zero, $
                                         TARGET=p0, FONT_SIZE=textfontsize, FONT_STYLE='bf')
                   t5 = text(0.52,0.915, 'avg_dev_2_fit: '+STRCOMPRESS(STRING(mean(ABS(dev_to_fit)), FORMAT='(D25.4)'), /REMOVE_ALL), $
                                         TARGET=p0, FONT_SIZE=textfontsize, FONT_STYLE='bf')
-                  t3.FONT_COLOR='b'
-                  t4.FONT_COLOR='b'
-                  t5.FONT_COLOR='r'
+                  t3.FONT_COLOR = 'b'
+                  t4.FONT_COLOR = 'b'
+                  t5.FONT_COLOR = 'r'
                 ENDIF ELSE BEGIN
                   t3 = text(0.02,0.915, 'corrected max dev-2-zero: '+STRCOMPRESS(STRING(MAX(ABS(y_corr), ix_max), FORMAT='(D25.4)'), /REMOVE_ALL), $
                                         TARGET=p0, FONT_SIZE=textfontsize, FONT_STYLE='bf')
                   t4 = text(0.26,0.915, '('+STRCOMPRESS(STRING(MAX(ABS(y_corr))/x[ix_max]*100D, FORMAT='(D25.4)'), /REMOVE_ALL)+' % of MR)', $
                                         TARGET=p0, FONT_SIZE=textfontsize, FONT_STYLE='bf')
-                  t3.FONT_COLOR='b'
-                  t4.FONT_COLOR='b'
+                  t3.FONT_COLOR = 'b'
+                  t4.FONT_COLOR = 'b'
                 ENDELSE
 
                 IF KEYWORD_SET(saveplot) THEN BEGIN
-                  IF estimate_cal THEN suffix='_'+match_substs[i]+'_cal_MR'+pic_filetype $
+                  IF estimate_cal THEN suffix = '_'+match_substs[i]+'_cal_MR'+pic_filetype $
                     ELSE suffix='_'+match_substs[i]+'_NL'+pic_filetype
                   p0.save, saveplot+suffix, resolution=300
                   p0.close

--- a/Tools_data/dp_nlexp_analyse.pro
+++ b/Tools_data/dp_nlexp_analyse.pro
@@ -119,8 +119,8 @@ FUNCTION dp_nlexp_analyse, fct_dgr, sel_exp, sel_subst, FORCE_ZERO=force_zero, $
         sel_name = WHERE((dp_chrom[sel_exp])[0].subst.name EQ match_substs[i]) ; substance name
 
         IF NOT estimate_cal THEN BEGIN
-          mrs[*,i]=dp_calc_mrs(match_substs[i], sel_name, sel_exp, dp_chrom, dp_expcfg, eval_mode)
-          w_subst=WHERE(*(dp_expcfg[sel_exp]).cal_mrs.substance EQ match_substs[i], n_match_mr)
+          mrs[*,i] = dp_calc_mrs(match_substs[i], sel_name, sel_exp, dp_chrom, dp_expcfg)
+          w_subst = WHERE(*(dp_expcfg[sel_exp]).cal_mrs.substance EQ match_substs[i], n_match_mr)
           cal_MR_spec = (*(dp_expcfg[sel_exp]).cal_mrs.mr_ppt)[w_subst[0]]
           cal_MR_err = (*(dp_expcfg[sel_exp]).cal_mrs.unc_ppt)[w_subst[0]]
         ENDIF ELSE BEGIN

--- a/Tools_data/dp_nlexp_analyse.pro
+++ b/Tools_data/dp_nlexp_analyse.pro
@@ -117,9 +117,9 @@ FUNCTION dp_nlexp_analyse, fct_dgr, sel_exp, sel_subst, FORCE_ZERO=force_zero, $
     FOR i=0, N_ELEMENTS(match_substs)-1 DO BEGIN ; substances loop
 
         sel_name = WHERE((dp_chrom[sel_exp])[0].subst.name EQ match_substs[i]) ; substance name
-  
+
         IF NOT estimate_cal THEN BEGIN
-          mrs[*,i]=dp_calc_mrs(match_substs[i], sel_name, sel_exp, dp_chrom, dp_expcfg)
+          mrs[*,i]=dp_calc_mrs(match_substs[i], sel_name, sel_exp, dp_chrom, dp_expcfg, eval_mode)
           w_subst=WHERE(*(dp_expcfg[sel_exp]).cal_mrs.substance EQ match_substs[i], n_match_mr)
           cal_MR_spec=(*(dp_expcfg[sel_exp]).cal_mrs.mr_ppt)[w_subst[0]]
           cal_MR_err=(*(dp_expcfg[sel_exp]).cal_mrs.unc_ppt)[w_subst[0]]
@@ -127,13 +127,13 @@ FUNCTION dp_nlexp_analyse, fct_dgr, sel_exp, sel_subst, FORCE_ZERO=force_zero, $
           cal_MR_spec = !VALUES.D_NAN
           cal_MR_err = !VALUES.D_NAN
         ENDELSE
-  
+
         ; generate a corresponding array with "actual" target mixing ratios (as defined)
         w_sel_subst = WHERE(*(dp_expcfg[sel_exp]).tgt_mrs.substance EQ match_substs[i])
         sel_subst_mrs = (*(dp_expcfg[sel_exp]).tgt_mrs.mr_ppt)[w_sel_subst]
         sel_subst_unc = (*(dp_expcfg[sel_exp]).tgt_mrs.unc_rel)[w_sel_subst]
         sel_subst_tgts = (*(dp_expcfg[sel_exp]).tgt_mrs.tgt_name)[w_sel_subst]
-  
+
         FOR j=0, n_meas-1 DO BEGIN ; targets loop
           w_mr = WHERE(sel_subst_tgts EQ s_names[j], nw)
           IF nw GT 0 THEN BEGIN
@@ -142,12 +142,12 @@ FUNCTION dp_nlexp_analyse, fct_dgr, sel_exp, sel_subst, FORCE_ZERO=force_zero, $
             s_names_arr[j,i] = s_names[j]
           ENDIF
         ENDFOR ; end targets loop
-  
+
         ; targtes: implement use flag and determine range
         tmp = (tgt_mrs[*,i])
         tmp[WHERE(use_flag EQ 0)] = !VALUES.D_NAN
         (tgt_mrs[*,i]) = TEMPORARY(tmp)
-  
+
         ; get relative responses of samples (targets)
         sequence = (dp_expcfg[sel_exp]).sequence
         s_ix = (sequence.ix_init_samblock)[WHERE(sequence.ix_init_samblock NE -1)]
@@ -157,15 +157,15 @@ FUNCTION dp_nlexp_analyse, fct_dgr, sel_exp, sel_subst, FORCE_ZERO=force_zero, $
           1: samples_rR = ((dp_chrom[sel_exp]).subst[sel_name].rres.rsp_height.sam_rrsp)
         ENDCASE
         IF n_inv GT 0 THEN samples_rR[inv_ix] = !VALUES.D_NAN
-  
+
         FOR k=0, N_ELEMENTS(u_tgt)-1 DO BEGIN
           w_tgt = WHERE(s_names_arr[*,i] EQ u_tgt[k], nw)
           IF nw GT 0 THEN $
             mrs_rsd[w_tgt,i] = stddev(samples_rR[w_tgt], /NAN) / mean(samples_rR[w_tgt], /NAN)
         ENDFOR
-  
+
         delta_mrs[*,i] = mrs[*,i] - tgt_mrs[*,i]
-  
+
         ; sort stuff out for fitting...
         IF estimate_cal THEN BEGIN
             w_fin = WHERE(FINITE(tgt_mrs[*,i]) EQ 1)
@@ -175,24 +175,24 @@ FUNCTION dp_nlexp_analyse, fct_dgr, sel_exp, sel_subst, FORCE_ZERO=force_zero, $
             n_fin = N_ELEMENTS(w_fin)
         ENDIF ELSE $
             w_fin = WHERE(FINITE(delta_mrs[*,i]) EQ 1, n_fin)
-  
+
         IF n_fin LT 2 THEN status=-1
-  
+
         sort_ix = SORT((tgt_mrs[*,i])[w_fin])
         tgt_mr_range = [MIN(((tgt_mrs[*,i])[w_fin])[sort_ix], /NAN),MAX(((tgt_mrs[*,i])[w_fin])[sort_ix], /NAN)]
-  
+
         ; get measurement precision and write to cal_norm_resp variable
         measure_errors = ((mrs_rsd[*,i])[w_fin])[sort_ix]
         invd_ix = WHERE(FINITE(measure_errors) EQ 0, n_invd)
         IF n_invd GT 0 THEN measure_errors[invd_ix] = mean(measure_errors, /NAN)
-  
+
         cal_norm_resp=[1D, $ ; if relative response is used, cal is 1 by definition
                        mean(measure_errors, /NAN)] ;  + mean((*(dp_expcfg[sel_exp]).tgt_mrs.unc_rel)[w_sel_subst], /NAN)
-  
+
         ; calculate error estimates for fit: measurement precision + uncertainty given for the targets
         measure_errors = measure_errors+((tgt_unc_rel[*,i])[w_fin])[sort_ix]
         measure_errors[WHERE(measure_errors LT 0.0001)] = 0.0001
-  
+
         IF estimate_cal THEN BEGIN
           XTITLE='relative detector response'
           YTITLE='target MR'
@@ -206,7 +206,7 @@ FUNCTION dp_nlexp_analyse, fct_dgr, sel_exp, sel_subst, FORCE_ZERO=force_zero, $
           x=((mrs[*,i])[w_fin])[sort_ix]
           y=((delta_mrs[*,i])[w_fin])[sort_ix]
         ENDELSE
-  
+
         ; derive mean values, different number of measurements per target are accounted for
         ; through the error of the mean SD/SQRT(n)
         snames=((s_names_arr[*,i])[w_fin])[sort_ix]
@@ -224,7 +224,7 @@ FUNCTION dp_nlexp_analyse, fct_dgr, sel_exp, sel_subst, FORCE_ZERO=force_zero, $
             e_means[k]=mean(measure_errors[w_tgt], /NAN)/SQRT(nw)
           ENDIF
         ENDFOR
-  
+
   ; +++ MOD
   ;      IF match_substs[0] EQ 'SF6' THEN force_zero=1
   ;      measure_errors[*]=0.01D
@@ -236,7 +236,7 @@ FUNCTION dp_nlexp_analyse, fct_dgr, sel_exp, sel_subst, FORCE_ZERO=force_zero, $
           e_plot=e_plot[w_fin_x]
         ENDIF
   ; +++
-  
+
         IF force_zero THEN BEGIN
           x=[0D,x]
           y=[0D,y]
@@ -244,27 +244,27 @@ FUNCTION dp_nlexp_analyse, fct_dgr, sel_exp, sel_subst, FORCE_ZERO=force_zero, $
           e_plot=[0.000001D,e_plot]
           e_means=[0.000001D, e_plot]
         ENDIF
-        
-    
+
+
         IF status NE -1 THEN $
             parms = poly_fit(x, y, fct_dgr, MEASURE_ERRORS=measure_errors,$
                              SIGMA=sigma, STATUS=status)
-  
-  
+
+
         IF status EQ 0 OR status EQ 2 THEN BEGIN ; polyfit successful completed?
-  
+
             fit_delta = polyfit_get_ydata(fct_dgr, x, parms)
-  
+
   ; +++ MOD
   ;        IF match_substs[0] EQ 'N2O' THEN fit_x = interpol([MIN([280D, x], /NAN),MAX(x, /NAN)], N_ELEMENTS(x)) $
   ;          ELSE fit_x = interpol([MIN(x, /NAN),MAX(x, /NAN)], N_ELEMENTS(x))
   ; +++
-  
+
             fit_x = interpol([MIN(x, /NAN),MAX(x, /NAN)], 200)
             fit_smooth = polyfit_get_ydata(fct_dgr, fit_x, parms)
             dev_to_fit = polyfit_get_ydata(fct_dgr, x, parms) - y
             n_fold_sd=1D
-  
+
   ; +++ MOD
   ;        ; derive ascension angle alpha from polyfit parms
   ;        c = SQRT(parms[1]^2 + 1D)
@@ -293,7 +293,7 @@ FUNCTION dp_nlexp_analyse, fct_dgr, sel_exp, sel_subst, FORCE_ZERO=force_zero, $
   ;
   ;        y_upper=polyfit_get_ydata(1, [280D,x_bound_0], p_upper)
   ;        y_lower=polyfit_get_ydata(1, [280D,x_bound_1], p_lower)
-  
+
   ;        p_upper=poly_fit([MIN(x,ix_min),MAX(x,ix_max)], $
   ;                         [mean(y-fit_delta)+n_fold_sd*stddev(y-fit_delta,/NAN),mean(y-fit_delta)-n_fold_sd*stddev(y-fit_delta,/NAN)], 1)
   ;        p_lower=poly_fit([MIN(x,ix_min),MAX(x,ix_max)], $
@@ -303,33 +303,33 @@ FUNCTION dp_nlexp_analyse, fct_dgr, sel_exp, sel_subst, FORCE_ZERO=force_zero, $
   ;        y_upper=polyfit_get_ydata(1, [280D,x_bound_0], p_upper)
   ;        y_lower=polyfit_get_ydata(1, [280D,x_bound_1], p_lower)
   ; +++
-  
+
             w_cal = WHERE((sequence.id) EQ id_cal, n_cal)
             cal_name = s_names[w_cal[0]]
-  
+
             IF estimate_cal THEN BEGIN
                 x_corr = [!VALUES.D_NAN, cal_norm_resp[0], !VALUES.D_NAN]
                 y_corr = [!VALUES.D_NAN, polyfit_get_ydata(fct_dgr, cal_norm_resp[0], parms), !VALUES.D_NAN]
                 fit_x = interpol([MIN([x,x_corr], /NAN), MAX([x,x_corr], /NAN)], 200)
                 fit_smooth = polyfit_get_ydata(fct_dgr, fit_x, parms)
-            
+
                 cal_est_MR = y_corr[1]
                 cal_est_sig = y_corr[1]*cal_norm_resp[1]
-      
+
                 IF cal_est_MR LT tgt_mr_range[0] OR cal_est_MR GT tgt_mr_range[1] $
                   THEN calMR_inTGTrange = 0 ELSE calMR_inTGTrange = 1
-      
+
                 e_plot=[!VALUES.D_NAN,cal_est_sig,!VALUES.D_NAN]
-      
+
                 msg = [cal_name, $
                        'estimated Cal MR: ', $
                        STRCOMPRESS(STRING(y_corr[1], FORMAT='(D25.5)'), /REMOVE_ALL),$
                        'abs. precision: ', $
                        STRCOMPRESS(STRING(cal_est_sig, FORMAT='(D25.8)'), /REMOVE_ALL),$
                        'in TGT MR range: '+STRING(calMR_inTGTrange)]
-      
+
                 IF loud THEN !NULL=DIALOG_MESSAGE(msg, /INFORMATION)
-    
+
             ENDIF ELSE BEGIN
                 x_corr = x
                 y_corr = (y-fit_delta)
@@ -338,7 +338,7 @@ FUNCTION dp_nlexp_analyse, fct_dgr, sel_exp, sel_subst, FORCE_ZERO=force_zero, $
                 IF cal_MR_spec LT tgt_mr_range[0] OR cal_MR_spec GT tgt_mr_range[1] $
                   THEN calMR_inTGTrange=0 ELSE calMR_inTGTrange=1
             ENDELSE
-    
+
             ; fill nl structure, create if first loop iteration
             IF i EQ 0 THEN nl_strct=REPLICATE(create_ref_nl(fct_dgr, N_ELEMENTS(((mrs[*,i])[w_fin])[sort_ix])), N_ELEMENTS(match_substs))
               nl_strct[i].species = match_substs[i]
@@ -357,16 +357,16 @@ FUNCTION dp_nlexp_analyse, fct_dgr, sel_exp, sel_subst, FORCE_ZERO=force_zero, $
               nl_strct[i].tgt_names = ((s_names_arr[*,i])[w_fin])[sort_ix]
               nl_strct[i].tgt_mrs = ((tgt_mrs[*,i])[w_fin])[sort_ix]
               nl_strct[i].delta_mrs = ((delta_mrs[*,i])[w_fin])[sort_ix]
-    
+
             IF show_plots THEN BEGIN
-    
+
                 min_x=MIN([MIN(x),MIN(fit_x),MIN(x_corr,/NAN)])
                 max_x=MAX([MAX(x),MAX(fit_x),MAX(x_corr,/NAN)])
                 min_y=MIN([MIN(y),MIN(fit_smooth),MIN(y_corr,/NAN)])
                 max_y=MAX([MAX(y),MAX(fit_smooth),MAX(y_corr,/NAN)])
                 xrange=[min_x-0.04*(max_x-min_x),max_x+0.04*(max_x-min_x)]
                 yrange=[min_y-0.1*(max_y-min_y), max_y+0.1*(max_y-min_y)]
-      
+
                 p0 = plot(x, y, XRANGE=xrange, YRANGE=yrange, $
                           DIMENSIONS=[1400,900], MARGIN=[0.1,0.1,0.1,0.1], $
                           SYMBOL='td',SYM_FILLED=1, $ ;TITLE=match_substs[i]
@@ -383,12 +383,12 @@ FUNCTION dp_nlexp_analyse, fct_dgr, sel_exp, sel_subst, FORCE_ZERO=force_zero, $
       ; +++
                 l = legend(TARGET=[p0,p1,p2], /DATA, /AUTO_TEXT_COLOR)
                 l.position = [0.99,0.99]
-      
+
                 textfontsize=14
                 t0 = text(0.02,0.95, match_substs[i], TARGET=p0, FONT_SIZE=textfontsize, FONT_STYLE='bf')
                 t1 = text(0.26,0.95, exp_fname, TARGET=p0, FONT_SIZE=textfontsize, FONT_STYLE='bf')
                 t2 = text(0.52,0.95, 'Cal: '+cal_name, TARGET=p0, FONT_SIZE=textfontsize, FONT_STYLE='bf')
-      
+
                 IF estimate_cal THEN BEGIN
                   t3 = text(0.02,0.915, 'est_Cal_MR: '+STRCOMPRESS(STRING(y_corr[1], FORMAT='(D25.4)'), /REMOVE_ALL), $
                                         TARGET=p0, FONT_SIZE=textfontsize, FONT_STYLE='bf')
@@ -407,16 +407,16 @@ FUNCTION dp_nlexp_analyse, fct_dgr, sel_exp, sel_subst, FORCE_ZERO=force_zero, $
                   t3.FONT_COLOR='b'
                   t4.FONT_COLOR='b'
                 ENDELSE
-      
+
                 IF KEYWORD_SET(saveplot) THEN BEGIN
                   IF estimate_cal THEN suffix='_'+match_substs[i]+'_cal_MR'+pic_filetype $
                     ELSE suffix='_'+match_substs[i]+'_NL'+pic_filetype
                   p0.save, saveplot+suffix, resolution=300
                   p0.close
                 ENDIF
-    
+
             ENDIF ; end: show plots
-    
+
             IF verbose THEN BEGIN
               print, '+++'
               print, match_substs[i], ' fct dgr: ', STRING(fct_dgr)
@@ -426,7 +426,7 @@ FUNCTION dp_nlexp_analyse, fct_dgr, sel_exp, sel_subst, FORCE_ZERO=force_zero, $
               print, 'mean delta after correction: ', mean(ABS(y-fit_delta))
               print, 'corrected delta vs. mean MR [%]: ', 100D*mean(ABS(y-fit_delta))/mean(x)
             ENDIF
-  
+
         ENDIF ELSE BEGIN ; end: fit successful
             IF loud THEN msg=DIALOG_MESSAGE('Fit failed.', /ERROR)
             RETURN, !NULL

--- a/Tools_data/dp_prcexp_analyse_prc.pro
+++ b/Tools_data/dp_prcexp_analyse_prc.pro
@@ -30,7 +30,7 @@ FUNCTION dp_prcexp_analyse_prc, sel_exp, min_blsz, max_blsz, cal_blsz, $
   COMMON DP_DATA
   COMMON DP_WIDID
 
-  IF NOT KEYWORD_SET(verbose) THEN verbose=0
+  IF NOT KEYWORD_SET(verbose) THEN verbose = 0
 
   strct = !NULL
   mpexp_cfg = dp_prcexp_analyse_seq(sel_exp, dp_expcfg, sid_name, VERBOSE=verbose)

--- a/Tools_data/dp_prcexp_analyse_seq.pro
+++ b/Tools_data/dp_prcexp_analyse_seq.pro
@@ -14,8 +14,8 @@ FUNCTION dp_prcexp_analyse_seq, sel_exp, dp_expcfg, sid_name, MIN_N_BLOCKS=min_n
                                 VERBOSE=verbose
 
 
-  IF NOT KEYWORD_SET(verbose) THEN verbose=0
-  IF NOT KEYWORD_SET(min_n_blocks) THEN min_n_blocks=5.
+  IF NOT KEYWORD_SET(verbose) THEN verbose = 0
+  IF NOT KEYWORD_SET(min_n_blocks) THEN min_n_blocks = 5.
 
   seq = (dp_expcfg[sel_exp]).sequence
 
@@ -26,24 +26,24 @@ FUNCTION dp_prcexp_analyse_seq, sel_exp, dp_expcfg, sid_name, MIN_N_BLOCKS=min_n
 
   IF seq.n_cal_blocks NE 1 THEN BEGIN
 
-    msg=DIALOG_MESSAGE('Number of Cal Blocks NE 1; Prerequisite for Precision Experiment Analysis!')
-    abort=1
-    n_cals=-1
-    blsz_min=-1
-    blsz_max=-1
+    msg = DIALOG_MESSAGE('Number of Cal Blocks NE 1; Prerequisite for Precision Experiment Analysis!')
+    abort = 1
+    n_cals = -1
+    blsz_min = -1
+    blsz_max = -1
 
     min_bl_val= [-1]
     max_bl_val= [-1]
 
   ENDIF ELSE BEGIN
 
-    abort=0
-    n_cals=seq.ix_end_calblock[0]-seq.ix_init_calblock[0]+1
-    blsz_min=1
+    abort = 0
+    n_cals = seq.ix_end_calblock[0]-seq.ix_init_calblock[0]+1
+    blsz_min = 1
     blsz_max=FLOOR(n_cals/FIX(min_n_blocks, TYPE=5))
 
-    min_bl_val=LINDGEN(blsz_max-blsz_min+1)+blsz_min
-    max_bl_val=min_bl_val
+    min_bl_val = LINDGEN(blsz_max-blsz_min+1)+blsz_min
+    max_bl_val = min_bl_val
 
   ENDELSE
 

--- a/Tools_data/dp_prcexp_wid_ini.pro
+++ b/Tools_data/dp_prcexp_wid_ini.pro
@@ -42,7 +42,7 @@ PRO dp_prcexp_wid_handle, event
 
   uname = WIDGET_INFO(event.id, /UNAME)
 
-;  verbose=1
+;  verbose = 1
 
   CASE uname OF
     ;******************************************************************************************

--- a/Tools_data/dp_replace_substnames.pro
+++ b/Tools_data/dp_replace_substnames.pro
@@ -19,14 +19,14 @@ PRO dp_replace_substnames, PATH=path, DEF_FILE=def_file
 
   import=read_csv(file, N_TABLE_HEADER=5, TABLE_HEADER=TableHeader, COUNT=count)
 
-  n_exp=N_ELEMENTS(dp_chrom)
+  n_exp = N_ELEMENTS(dp_chrom)
 
   FOR i=0, n_exp-1 DO BEGIN ; begin loop: search & replace strings
-    tmp_chrom=(dp_chrom)[i]
-    tmp_subst=(substlist)[i]
+    tmp_chrom = (dp_chrom)[i]
+    tmp_subst = (substlist)[i]
     tmp_subst=strreplace_iter(tmp_subst, ',', '', n_iter=5) ; remove nasty stuff from msinfo...
-    n_subst=N_ELEMENTS(tmp_subst)
-    n_chrom=N_ELEMENTS(tmp_chrom)
+    n_subst = N_ELEMENTS(tmp_subst)
+    n_chrom = N_ELEMENTS(tmp_chrom)
 
     FOR j=0, count-1 DO BEGIN ; begin loop: experiments
       tmp=strsplit(STRTRIM(import.field1[j]), ';', /EXTRACT)
@@ -40,9 +40,9 @@ PRO dp_replace_substnames, PATH=path, DEF_FILE=def_file
     new_subst=STRARR(n_subst, n_chrom) ; generate names matrix; n_subst x n_chrom
     FOR k=0, n_chrom-1 DO new_subst[*,k]=tmp_subst
 
-    (tmp_chrom.subst.name)=new_subst
-    (substlist)[i]=tmp_subst
-    (dp_chrom)[i]=tmp_chrom
+    (tmp_chrom.subst.name) = new_subst
+    (substlist)[i] = tmp_subst
+    (dp_chrom)[i] = tmp_chrom
   ENDFOR ; end loop: experiments
 
   dp_refr_status, MESSAGE='Updated substance names.

--- a/Tools_general/STRCT_Redefine_Tag.pro
+++ b/Tools_general/STRCT_Redefine_Tag.pro
@@ -56,9 +56,9 @@ FUNCTION STRCT_Redefine_Tag, Struct, Tag_Name=tag_name, Tag_Def=tag_def
 ;   Written by Harald Boenisch, IAU, University Frankfurt, 22. October, 2012.
 ;-
 ;------------------------------------------------------------------
-  IF NOT keyword_set(tag_def) THEN tag_def=!NULL
+  IF NOT keyword_set(tag_def) THEN tag_def = !NULL
 
-  tag_names=tag_names(struct)
+  tag_names = tag_names(struct)
 
   w=where(tag_names EQ strupcase(tag_name[0]),nw)
 
@@ -67,8 +67,8 @@ FUNCTION STRCT_Redefine_Tag, Struct, Tag_Name=tag_name, Tag_Def=tag_def
     RETURN, struct_new
   ENDIF
 
-  n=0
-  struct_new=!NULL
+  n = 0
+  struct_new = !NULL
   IF (w EQ 0) THEN BEGIN
     IF size(tag_def, /type) NE 0 THEN struct_new=create_struct(struct_new,tag_names[0],tag_def)
   ENDIF ELSE struct_new=create_struct(tag_names[0],struct.(n))

--- a/Tools_general/arr1D_get_matchIX.pro
+++ b/Tools_general/arr1D_get_matchIX.pro
@@ -27,8 +27,8 @@ FUNCTION arr1D_get_matchIX, ref_arr, comp_arr, CASE_SENSI=case_sensi, NO_MATCH_I
 
   ; check for string type and case sensitive keyword
   IF type_ref EQ 7 AND NOT KEYWORD_SET(case_sensi) THEN BEGIN
-    ref_arr=STRUPCASE(TEMPORARY(ref_arr))
-    comp_arr=STRUPCASE(TEMPORARY(comp_arr))
+    ref_arr = STRUPCASE(TEMPORARY(ref_arr))
+    comp_arr = STRUPCASE(TEMPORARY(comp_arr))
   ENDIF
 
   match_ix=MAKE_ARRAY(N_ELEMENTS(ref_arr), /LONG, VALUE=-1)
@@ -40,8 +40,8 @@ FUNCTION arr1D_get_matchIX, ref_arr, comp_arr, CASE_SENSI=case_sensi, NO_MATCH_I
   IF n_m GT 0 THEN $
     match_ix=match_ix[WHERE(match_ix NE -1, COMPLEMENT=no_match_ix)] $
   ELSE BEGIN
-    match_ix=-1
-    no_match_ix=-1
+    match_ix = -1
+    no_match_ix = -1
   ENDELSE
 
   RETURN, match_ix

--- a/Tools_general/codecleaner.py
+++ b/Tools_general/codecleaner.py
@@ -1,4 +1,29 @@
 from pathlib import Path
+import re
+
+eq_wo_spaces = re.compile('[^\ ]\=[^\ ]')
+
+
+
+def set_spaceequalspace(content):
+    out = []
+    for i, s in enumerate(content):
+        vd = (',' not in s)
+        if i > 0:
+            vd = (vd and
+                  ('pro' not in content[i-1].lower()) and
+                  ('function' not in content[i-1].lower()) and
+                  ('$' not in content[i-1]))
+        if vd:
+            if r := re.search(eq_wo_spaces, s):
+                out.append(s[:r.span()[0]+1] + " = " + s[r.span()[1]-1:])
+            else:
+                out.append(s)
+        else:
+            out.append(s)
+    return out
+
+
 
 def rmv_endspace(s):
     s = s.replace(' \n', '\n')
@@ -6,12 +31,15 @@ def rmv_endspace(s):
         return rmv_endspace(s)
     return s
 
+
+
 if __name__ == '__main__':
     for f in list(Path('../').rglob('*.pro')):
         with open(f, 'r') as fobj:
             content = fobj.readlines()
 
         content_out = [rmv_endspace(l) for l in content]
+        content_out = set_spaceequalspace(content_out)
 
         with open(f, 'w') as fobj:
             fobj.writelines(content_out)

--- a/Tools_general/codecleaner.py
+++ b/Tools_general/codecleaner.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+def rmv_endspace(s):
+    s = s.replace(' \n', '\n')
+    if s.find(' \n') != -1:
+        return rmv_endspace(s)
+    return s
+
+if __name__ == '__main__':
+    for f in list(Path('../').rglob('*.pro')):
+        with open(f, 'r') as fobj:
+            content = fobj.readlines()
+
+        content_out = [rmv_endspace(l) for l in content]
+
+        with open(f, 'w') as fobj:
+            fobj.writelines(content_out)

--- a/Tools_general/polyfit_get_ydata.pro
+++ b/Tools_general/polyfit_get_ydata.pro
@@ -3,10 +3,10 @@ FUNCTION polyfit_get_ydata, fct_dgr, xdata, parms
   ydata = DBLARR(N_ELEMENTS(xdata))
 
   CASE fct_dgr OF
-    1: ydata[*]=parms[0]+parms[1]*xdata[*]
-    2: ydata[*]=parms[0]+parms[1]*xdata[*]+parms[2]*xdata[*]^2
-    3: ydata[*]=parms[0]+parms[1]*xdata[*]+parms[2]*xdata[*]^2+parms[3]*xdata[*]^3
-    4: ydata[*]=parms[0]+parms[1]*xdata[*]+parms[2]*xdata[*]^2+parms[3]*xdata[*]^3+parms[4]*xdata[*]^4
+    1: ydata[*] = parms[0]+parms[1]*xdata[*]
+    2: ydata[*] = parms[0]+parms[1]*xdata[*]+parms[2]*xdata[*]^2
+    3: ydata[*] = parms[0]+parms[1]*xdata[*]+parms[2]*xdata[*]^2+parms[3]*xdata[*]^3
+    4: ydata[*] = parms[0]+parms[1]*xdata[*]+parms[2]*xdata[*]^2+parms[3]*xdata[*]^3+parms[4]*xdata[*]^4
   ENDCASE
 
   RETURN, ydata

--- a/Tools_general/str_get_formcode.pro
+++ b/Tools_general/str_get_formcode.pro
@@ -4,8 +4,8 @@ FUNCTION str_get_formcode, typestr, n
   IF STRLEN(typestr) GT 6 THEN RETURN, !NULL
   IF SIZE(n, /TYPE) GT 3 THEN RETURN, !NULL
 
-  prefix='('
-  suffix=')'
+  prefix = '('
+  suffix = ')'
 
   str=typestr+','
 

--- a/Tools_general/strreplace_iter.pro
+++ b/Tools_general/strreplace_iter.pro
@@ -10,11 +10,11 @@
 ;--------------------------------------------------------------------------------------------------------------------
 FUNCTION strreplace_iter, Strings, Find1, Replacement1, N_ITER=n_iter, NO_CASE=no_case
 
-  IF NOT KEYWORD_SET(n_iter) THEN n_iter=1
-  IF n_iter LT 1 THEN n_iter=1
+  IF NOT KEYWORD_SET(n_iter) THEN n_iter = 1
+  IF n_iter LT 1 THEN n_iter = 1
 
   NP        = N_PARAMS()  ;   Check integrity of input parameter
-  IF (NP NE 3) THEN msg=DIALOG_MESSAGE('Must be called with 3 parameters: '+$
+  IF (NP NE 3) THEN msg = DIALOG_MESSAGE('Must be called with 3 parameters: '+$
                                        'Strings, Find, Replacement.', /ERROR)
 
   sz        = SIZE(Strings)

--- a/Tools_general/time2jultime.pro
+++ b/Tools_general/time2jultime.pro
@@ -9,14 +9,14 @@ FUNCTION time2jultime, DATE=date, TIME=time, INPUT_IS_MDY=input_is_mdy, $
                        DEL_DATE=del_date, DEL_TIME=del_time
 
   IF NOT KEYWORD_SET(date) THEN BEGIN
-    date='01.01.1900'
-    no_date=1
-  ENDIF ELSE no_date=0
+    date = '01.01.1900'
+    no_date = 1
+  ENDIF ELSE no_date = 0
 
   IF NOT KEYWORD_SET(time) THEN BEGIN
-    time='00:00:00'
-    no_time=1
-  ENDIF ELSE no_time=0
+    time = '00:00:00'
+    no_time = 1
+  ENDIF ELSE no_time = 0
 
   IF NOT KEYWORD_SET(input_is_mdy) THEN ix = [1,0,2,0,1,2] $
     ELSE ix = [0,1,2,0,1,2]
@@ -24,8 +24,8 @@ FUNCTION time2jultime, DATE=date, TIME=time, INPUT_IS_MDY=input_is_mdy, $
   ; neither date nor time given...
   IF no_date+no_time EQ 2 THEN RETURN, !VALUES.D_NAN
 
-  IF NOT KEYWORD_SET(del_date) THEN del_date='.'
-  IF NOT KEYWORD_SET(del_time) THEN del_time=':'
+  IF NOT KEYWORD_SET(del_date) THEN del_date = '.'
+  IF NOT KEYWORD_SET(del_time) THEN del_time = ':'
 
   ; given string too short, return NaN
   IF STRLEN(date) LE 3 OR STRLEN(time) LE 3 THEN RETURN, !VALUES.D_NAN
@@ -33,8 +33,8 @@ FUNCTION time2jultime, DATE=date, TIME=time, INPUT_IS_MDY=input_is_mdy, $
   ; given string too long, assume a timestamp "dd.mm.yyyy hh:mn:ss"
   IF STRLEN(date) GT 10 OR STRLEN(time) GT 10 THEN BEGIN
     CASE 1 OF
-      (no_date EQ 1): v=time
-      (no_time EQ 1): v=date
+      (no_date EQ 1): v = time
+      (no_time EQ 1): v = date
       ELSE: RETURN, !VALUES.D_NAN
     ENDCASE
     date = STRMID(v, 0, 10)

--- a/Tools_general/txtfile_to_strct.pro
+++ b/Tools_general/txtfile_to_strct.pro
@@ -45,7 +45,7 @@ FUNCTION txtfile_to_strct, file, txtsep, nl_tbl_hdr
   FOR i=0L, nl-nl_tbl_hdr-1 DO $
     data[*,i]=strsplit(input[i+1], txtsep, /EXTRACT, /PRESERVE_NULL)
 
-  strct={}
+  strct = {}
   FOR i=0, n_parm-1 DO BEGIN
     valid = valid_num(data[i,0])
     IF valid THEN col_type = 5 ELSE col_type = 7


### PR DESCRIPTION
incorrect keyword `eval_mode` handling in `FUNCTION dp_calc_mrs` caused report files to always show area result, despite "height" being selected for evaluation.

This revision removes the keyword completely; the selected method (area or height) is extracted from the common data structure `dp_chrom` in-place.